### PR TITLE
Feat/bootnode healthcheck test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,8 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - os: linux
+  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+    os: linux
     dist: xenial
     go: 1.13.x
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ go_import_path: github.com/ethereum/go-ethereum
 sudo: false
 matrix:
   include:
-  - if: branch =~ ^ci-test-bootnode-availability
+  - if: commit_message =~ ci:test-bootnode-availability
     os: linux
     dist: xenial
     go: 1.13.x
+    env:
+    - bootnode-availability
     script:
     - make test-bootnode-availability
-  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
-    os: linux
+  - os: linux
     dist: xenial
     go: 1.13.x
     script:
@@ -31,8 +32,7 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
-    os: linux
+  - os: linux
     dist: xenial
     sudo: required
     go: 1.13.x
@@ -63,8 +63,7 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
-    os: osx
+  - os: osx
     go: 1.13.x
     script:
     - echo "Increase the maximum number of open file descriptors on macOS"
@@ -91,8 +90,7 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
-    os: linux
+  - os: linux
     dist: xenial
     go: 1.13.x
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,16 @@ go_import_path: github.com/ethereum/go-ethereum
 sudo: false
 matrix:
   include:
-  - os: linux
+  - if: branch =~ ^test-bootnode-availability
+    os: linux
     dist: xenial
     go: 1.13.x
-    branches:
-      only:
-      - /test-bootnode-availability\/.*/
     script:
     - make test-bootnode-availability
-  - os: linux
+  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+    os: linux
     dist: xenial
     go: 1.13.x
-    branches:
-      except:
-        - /test-bootnode-availability\/.*/
     script:
     - go run build/ci.go install
     - travis_wait 60 go run build/ci.go test
@@ -35,13 +31,11 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - os: linux
+  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+    os: linux
     dist: xenial
     sudo: required
     go: 1.13.x
-    branches:
-      except:
-        - /test-bootnode-availability\/.*/
     env:
       - ARMv5
     git:
@@ -69,11 +63,9 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - os: osx
+  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+    os: osx
     go: 1.13.x
-    branches:
-      except:
-        - /test-bootnode-availability\/.*/
     script:
     - echo "Increase the maximum number of open file descriptors on macOS"
     - NOFILE=20480

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,17 @@ matrix:
   - os: linux
     dist: xenial
     go: 1.13.x
+    branches:
+      only:
+      - /test-bootnode-availability\/.*/
+    script:
+    - make test-bootnode-availability
+  - os: linux
+    dist: xenial
+    go: 1.13.x
+    branches:
+      except:
+        - /test-bootnode-availability\/.*/
     script:
     - go run build/ci.go install
     - travis_wait 60 go run build/ci.go test
@@ -28,6 +39,9 @@ matrix:
     dist: xenial
     sudo: required
     go: 1.13.x
+    branches:
+      except:
+        - /test-bootnode-availability\/.*/
     env:
       - ARMv5
     git:
@@ -57,6 +71,9 @@ matrix:
       tag_name: "$TRAVIS_TAG"
   - os: osx
     go: 1.13.x
+    branches:
+      except:
+        - /test-bootnode-availability\/.*/
     script:
     - echo "Increase the maximum number of open file descriptors on macOS"
     - NOFILE=20480

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ go_import_path: github.com/ethereum/go-ethereum
 sudo: false
 matrix:
   include:
-  - if: branch =~ ^test-bootnode-availability
+  - if: branch =~ ^ci-test-bootnode-availability
     os: linux
     dist: xenial
     go: 1.13.x
     script:
     - make test-bootnode-availability
-  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
     os: linux
     dist: xenial
     go: 1.13.x
@@ -31,7 +31,7 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
     os: linux
     dist: xenial
     sudo: required
@@ -63,7 +63,7 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
     os: osx
     go: 1.13.x
     script:
@@ -91,7 +91,7 @@ matrix:
         tags: true
       skip_cleanup: true
       tag_name: "$TRAVIS_TAG"
-  - if: branch =~ /^((?!test-bootnode-availability).)*$/
+  - if: branch =~ /^((?!ci-test-bootnode-availability).)*$/
     os: linux
     dist: xenial
     go: 1.13.x

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ tests-generate-difficulty: ## Generate difficulty tests.
 	env MULTIGETH_TESTS_GENERATE_DIFFICULTY_TESTS=on \
 	go run build/ci.go test -v ./tests -run TestDifficultyGen
 
+test-bootnode-availability: ## Test default bootnode reachability by ping.
+	env MULTIGETH_TEST_BOOTNODE_AVAILABILITY=on go test -v ./integration -run TestBootnodes
+
 lint: ## Run linters.
 	go run build/ci.go lint
 

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -72,7 +72,7 @@ func testBootnodes(t *testing.T, nodes []string, minPassRate float64, maxTrials 
 	disc := startV4(t)
 
 	// Log self enode. This lets a reader be able to know IP + port in case that's useful.
-	t.Logf("IAM enode=%s", disc.Self().String())
+	t.Logf("IAM enode=%s v4=%s", disc.Self(), disc.Self().URLv4())
 
 	for _, n := range nodes {
 		en, err := enode.ParseV4(n)

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -88,6 +89,9 @@ nodesloop:
 }
 
 func TestBootnodesDiscV4Ping(t *testing.T) {
+	if os.Getenv("MULTIGETH_TEST_BOOTNODE_AVAILABILITY") != "on" {
+		t.Skip("Skipping bootnode availability tests.")
+	}
 	t.Parallel()
 
 	// MinPassRate defines the minimum tolerance for node OK rate

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -1,0 +1,135 @@
+package integration
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// startV4 starts an ephemeral discovery V4 node.
+func startV4(t *testing.T) *discover.UDPv4 {
+	socket, ln, cfg, err := listen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	disc, err := discover.ListenV4(socket, ln, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return disc
+}
+
+func listen() (*net.UDPConn, *enode.LocalNode, discover.Config, error) {
+	var cfg discover.Config
+	cfg.PrivateKey, _ = crypto.GenerateKey()
+	db, _ := enode.OpenDB("")
+	ln := enode.NewLocalNode(db, cfg.PrivateKey)
+
+	socket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{0, 0, 0, 0}})
+	if err != nil {
+		db.Close()
+		return nil, nil, cfg, err
+	}
+	addr := socket.LocalAddr().(*net.UDPAddr)
+	ln.SetFallbackIP(net.IP{127, 0, 0, 1})
+	ln.SetFallbackUDP(addr.Port)
+	return socket, ln, cfg, nil
+}
+
+func testBootnodes(t *testing.T, nodes []string, minPassRate float64, maxTrials int) {
+	if minPassRate == 0 {
+		t.Skip("minimum pass rate of 0 means no tests required")
+	}
+	if maxTrials == 0 {
+		t.Skip("no trials enabled")
+	}
+
+	total := len(nodes)
+	failed := 0
+	minPassN := float64(total) * minPassRate // Minimum number of nodes that must be reachable for the test not to fail.
+
+	// Case where pass rate is epsilon (but non-zero) and rounding causes n nodes == 0; infer that at least just 1 node must pass.
+	if minPassN == 0 {
+		minPassN = 1
+	}
+
+	disc := startV4(t)
+
+nodesloop:
+	for _, n := range nodes {
+		en, err := enode.ParseV4(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 1; i <= maxTrials; i++ {
+			err = disc.Ping(en)
+			if err == nil {
+				t.Logf("ping OK: enode=%s", en.String())
+				continue nodesloop
+			}
+		}
+		// Max trial attempts were reached, all with errors.
+		t.Logf("ping FAIL (%d/%d): enode=%s err=%v", maxTrials, maxTrials, en.String(), err)
+		failed++
+	}
+
+	okCount := total - failed
+	line := fmt.Sprintf("%.0f%% (%d / %d) nodes responded to ping (%d failed)", float64(okCount)/float64(total)*100, okCount, total, failed)
+	if okCount < int(minPassN) {
+		t.Error(line)
+	} else {
+		t.Log(line)
+	}
+}
+
+func TestBootnodesDiscV4Ping(t *testing.T) {
+	t.Parallel()
+
+	// MinPassRate defines the minimum tolerance for node OK rate
+	// 1.0 would require all nodes to pass, 0.0 would require none to pass.
+	epsilon := 0.01 // An epsilon pass rate (eg 0.01) will mean >= 1 node must succeed.
+	few := 0.3
+	some := 0.5
+	//most := 0.7
+	defaultMinPassRate := some
+
+	// MaxTrials.
+	none := 0 // No(ne) trials means no nodes must succeed (ie known complete bootnodes failure) and should at least be deprecated if not ruthlessly stricken.
+	defaultMaxTrials := 3
+
+	for _, c := range []struct {
+		Name        string
+		Bootnodes   []string
+		MinPassRate *float64
+		MaxTrials   *int
+	}{
+		{Name: "classic", Bootnodes: params.ClassicBootnodes},
+		{Name: "foundation", Bootnodes: params.MainnetBootnodes},
+		{Name: "kotti", Bootnodes: params.KottiBootnodes},
+		{Name: "goerli", Bootnodes: params.GoerliBootnodes, MinPassRate: &few},
+		{Name: "mordor", Bootnodes: params.MordorBootnodes, MinPassRate: &epsilon},
+		{Name: "ropsten", Bootnodes: params.TestnetBootnodes, MinPassRate: &epsilon},
+		{Name: "rinkeby", Bootnodes: params.RinkebyBootnodes},
+		{Name: "social", Bootnodes: params.SocialBootnodes, MaxTrials: &none},
+		{Name: "ethersocial", Bootnodes: params.EthersocialBootnodes},
+		{Name: "mix", Bootnodes: params.MixBootnodes},
+	} {
+		t.Run(fmt.Sprintf("%s", c.Name), func(t *testing.T) {
+			rate := defaultMinPassRate
+			if c.MinPassRate != nil {
+				rate = *c.MinPassRate
+			}
+			trials := defaultMaxTrials
+			if c.MaxTrials != nil {
+				trials = *c.MaxTrials
+			}
+
+			testBootnodes(t, c.Bootnodes, rate, trials)
+		})
+	}
+}

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -71,6 +71,9 @@ func testBootnodes(t *testing.T, nodes []string, minPassRate float64, maxTrials 
 
 	disc := startV4(t)
 
+	// Log self enode. This lets a reader be able to know IP + port in case that's useful.
+	t.Logf("IAM enode=%s", disc.Self().String())
+
 	for _, n := range nodes {
 		en, err := enode.ParseV4(n)
 		if err != nil {

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -119,7 +119,7 @@ func TestBootnodesDiscV4Ping(t *testing.T) {
 		{Name: "ethersocial", Bootnodes: params.EthersocialBootnodes},
 		{Name: "mix", Bootnodes: params.MixBootnodes},
 	} {
-		t.Run(fmt.Sprintf("%s", c.Name), func(t *testing.T) {
+		t.Run(c.Name, func(t *testing.T) {
 			rate := defaultMinPassRate
 			if c.MinPassRate != nil {
 				rate = *c.MinPassRate

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -43,11 +43,8 @@ func listen() (*net.UDPConn, *enode.LocalNode, discover.Config, error) {
 }
 
 func testBootnodes(t *testing.T, nodes []string, minPassRate float64, maxTrials int) {
-	if minPassRate == 0 {
-		t.Skip("minimum pass rate of 0 means no tests required")
-	}
 	if maxTrials == 0 {
-		t.Skip("no trials enabled")
+		t.Skip("trials disabled")
 	}
 
 	total := len(nodes)
@@ -55,7 +52,7 @@ func testBootnodes(t *testing.T, nodes []string, minPassRate float64, maxTrials 
 	minPassN := float64(total) * minPassRate // Minimum number of nodes that must be reachable for the test not to fail.
 
 	// Case where pass rate is epsilon (but non-zero) and rounding causes n nodes == 0; infer that at least just 1 node must pass.
-	if minPassN == 0 {
+	if minPassN == 0 && minPassRate > 0 {
 		minPassN = 1
 	}
 
@@ -92,10 +89,10 @@ func TestBootnodesDiscV4Ping(t *testing.T) {
 	if os.Getenv("MULTIGETH_TEST_BOOTNODE_AVAILABILITY") != "on" {
 		t.Skip("Skipping bootnode availability tests.")
 	}
-	t.Parallel()
 
 	// MinPassRate defines the minimum tolerance for node OK rate
 	// 1.0 would require all nodes to pass, 0.0 would require none to pass.
+	zero := 0.0
 	epsilon := 0.01 // An epsilon pass rate (eg 0.01) will mean >= 1 node must succeed.
 	few := 0.3
 	some := 0.5
@@ -103,7 +100,6 @@ func TestBootnodesDiscV4Ping(t *testing.T) {
 	defaultMinPassRate := some
 
 	// MaxTrials.
-	none := 0 // No(ne) trials means no nodes must succeed (ie known complete bootnodes failure) and should at least be deprecated if not ruthlessly stricken.
 	defaultMaxTrials := 3
 
 	for _, c := range []struct {
@@ -119,7 +115,7 @@ func TestBootnodesDiscV4Ping(t *testing.T) {
 		{Name: "mordor", Bootnodes: params.MordorBootnodes, MinPassRate: &epsilon},
 		{Name: "ropsten", Bootnodes: params.TestnetBootnodes, MinPassRate: &epsilon},
 		{Name: "rinkeby", Bootnodes: params.RinkebyBootnodes},
-		{Name: "social", Bootnodes: params.SocialBootnodes, MaxTrials: &none},
+		{Name: "social", Bootnodes: params.SocialBootnodes, MinPassRate: &zero},
 		{Name: "ethersocial", Bootnodes: params.EthersocialBootnodes},
 		{Name: "mix", Bootnodes: params.MixBootnodes},
 	} {

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -43,7 +43,7 @@ func listen() (*net.UDPConn, *enode.LocalNode, discover.Config, error) {
 	return socket, ln, cfg, nil
 }
 
-func checkENodePing(disc *discover.UDPv4, en *enode.Node, maxTrials int) (time.Duration, tookTrials int, error) {
+func checkENodePing(disc *discover.UDPv4, en *enode.Node, maxTrials int) (time.Duration, int, error) {
 	var err error
 	for i := 1; i <= maxTrials; i++ {
 		start := time.Now()

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -83,6 +83,7 @@ func testBootnodes(t *testing.T, nodes []string, minPassRate float64, maxTrials 
 		took, trials, err := checkENodePing(disc, en, maxTrials)
 		if err == nil {
 			t.Logf("OK enode=%s rtt=%v", en.String(), took)
+			continue
 		}
 
 		// Max trial attempts were reached, all with errors.

--- a/integration/bootnodes_test.go
+++ b/integration/bootnodes_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/discover"
@@ -65,19 +66,20 @@ nodesloop:
 			t.Fatal(err)
 		}
 		for i := 1; i <= maxTrials; i++ {
+			start := time.Now()
 			err = disc.Ping(en)
 			if err == nil {
-				t.Logf("ping OK: enode=%s", en.String())
+				t.Logf("OK (RTT %v): enode=%s", time.Since(start), en.String())
 				continue nodesloop
 			}
 		}
 		// Max trial attempts were reached, all with errors.
-		t.Logf("ping FAIL (%d/%d): enode=%s err=%v", maxTrials, maxTrials, en.String(), err)
+		t.Logf("FAIL (%d/%d): enode=%s err=%v", maxTrials, maxTrials, en.String(), err)
 		failed++
 	}
 
 	okCount := total - failed
-	line := fmt.Sprintf("%.0f%% (%d / %d) nodes responded to ping (%d failed)", float64(okCount)/float64(total)*100, okCount, total, failed)
+	line := fmt.Sprintf("=> %.0f%% (%d / %d) nodes responded to ping [min pass rate = %.02f, max trials = %d]", float64(okCount)/float64(total)*100, okCount, total, minPassRate, maxTrials)
 	if okCount < int(minPassN) {
 		t.Error(line)
 	} else {


### PR DESCRIPTION
Rel #9 (well, the healthcheck part. That issue should break into healthcheck vs. generator).
Rel https://github.com/etclabscore/multi-geth-fork/pull/149

This change set implements a basic ping healthcheck program for default bootnode lists.

---

There are challenges when addressing bootnode validations, all of which have to with what "availability" means and looks like on a decentralized p2p network. This feature - as implemented - doesn't really achieve much in the way of actually addressing those questions; it's more like a minimum-viable proof-of-concept and basic heuristic. 

I'm not sure that it should (yet? ever?) be merged, but can at least serve as some sort of maybe-useful reference.
