### PR TITLE
Release/v1.9.10

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 const (
 	VersionMajor = 1          // Major version component of the current release
 	VersionMinor = 9          // Minor version component of the current release
-	VersionPatch = 10         // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionPatch = 11         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1          // Major version component of the current release
 	VersionMinor = 9          // Minor version component of the current release
 	VersionPatch = 10         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
This'll be the first release under the new `core-geth` namespace... we'll see how the CI does :crossed_fingers: 

---

_Release notes draft_

> https://github.com/etclabscore/core-geth/releases

### Buffalo Buffalo Buffalo (v1.9.10)

- [x] Implements [ECIP1086](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1086.md). This specification is an allowance provisioning for ETC testnets Kotti and Mordor to continue to [incorrectly implement EIP2200](https://github.com/etclabscore/core-geth/commit/0cd6b91457f113d736301c6d08527d394d3b461f). Alternatively, the networks can be rolled back to a point prior to their implementation of EIP2200. [There is not firm human consensus on this issue yet (via the _Discussion-To_ link in ECIP1086)](https://github.com/ethereumclassic/ECIPs/issues/262). However, in balancing the needs to correctly implement things, to break as few things as possible, and to try to keep people on-board, we've decided to publish the ECIP1086 implementation "optimistically." This allows core-geth to not cause a fork on these testnets, and -- importantly -- does not preclude the option of rolling them back (in which case we'll simply remove the ECIP1086 feature as dead code).

- [x] As related above, implements the [EIP2200 gas cost fix](https://github.com/etclabscore/core-geth/commit/0cd6b91457f113d736301c6d08527d394d3b461f).

- [x] Implements [ECIP1078](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1078.md) _on ETC testnets Kotti and Mordor only_. Similar in logic to above, this is a compromise between specification and implementation timelines (since `Last Call` period end is after activation on these testnets, see [this PR](https://github.com/etclabscore/multi-geth-fork/pull/145) for some discussion on this).

- [x] And last but not least (as you may have already surmised :wink:) _renames the project to __Core-Geth___!
    - With significant development effort already invested (now approaching 800 commits ahead of our comrade and predecessor [multi-geth/multi-geth](https://github.com/multi-geth/multi-geth)), and an intention to continue growth, we think it's about the right time to fly our own flag. The aim is for this code base and the software it provides to continue serving ETC and entire Eth<sup>n</sup> ecosystem reliably and innovatively. We hope that renaming won't be a cause of political contention, but instead add another optimistic rallying point for configuration-freedom and an extensible, accessible Ethereum-as-protocol. :rocket: 

