### PR TITLE
discovery: add ETC support for discv4 DNS records

### DIFF
--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -165,6 +165,12 @@ func ethFilter(args []string) (nodeFilter, error) {
 		filter = forkid.NewStaticFilter(params.GoerliChainConfig, params.GoerliGenesisHash)
 	case "ropsten":
 		filter = forkid.NewStaticFilter(params.TestnetChainConfig, params.TestnetGenesisHash)
+	case "classic":
+		filter = forkid.NewStaticFilter(params.ClassicChainConfig, params.MainnetGenesisHash)
+	case "kotti":
+		filter = forkid.NewStaticFilter(params.KottiChainConfig, params.KottiGenesisHash)
+	case "mordor":
+		filter = forkid.NewStaticFilter(params.MordorChainConfig, params.MordorGenesisHash)
 	default:
 		return nil, fmt.Errorf("unknown network %q", args[0])
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1557,6 +1557,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		setDNSDiscoveryDefaults(cfg, params.KnownDNSNetworks[params.RinkebyGenesisHash])
 	case ctx.GlobalBool(GoerliFlag.Name):
 		setDNSDiscoveryDefaults(cfg, params.KnownDNSNetworks[params.GoerliGenesisHash])
+	case ctx.GlobalBool(ClassicFlag.Name):
+		setDNSDiscoveryDefaults(cfg, params.ClassicDNSNetwork1)
+	case ctx.GlobalBool(KottiFlag.Name):
+		setDNSDiscoveryDefaults(cfg, params.KottiDNSNetwork1)
+	case ctx.GlobalBool(MordorFlag.Name):
+		setDNSDiscoveryDefaults(cfg, params.MordorDNSNetwork1)
 	default:
 		if cfg.NetworkId == 1 {
 			setDNSDiscoveryDefaults(cfg, params.KnownDNSNetworks[params.MainnetGenesisHash])

--- a/params/bootnodes_classic.go
+++ b/params/bootnodes_classic.go
@@ -43,3 +43,7 @@ var ClassicBootnodes = []string{
 	"enode://70b74fef51aa4f36330cc52ac04f16d38e1838f531f58bbc88365ca5fd4a3da6e8ec32316c43f79b157d0575faf53064fd925644d0f620b2b201b028c2b410d0@47.115.150.90:30303",  //ETC Labs
 	"enode://fa64d1fcb2d4cd1d1606cb940ea2b69fee7dc6c7a85ac4ad05154df1e9ae9616a6a0fa67a59cb15f79346408efa5a4efeba1e5993ddbf4b5cedbda27644a61cf@47.91.30.48:30303",    //ETC Labs
 }
+
+var dnsPrefixETC = "enrtree://AJE62Q4DUX4QMMXEHCSSCSC65TDHZYSMONSD64P3WULVLSF6MRQ3K"
+
+var ClassicDNSNetwork1 = dnsPrefixETC + "all.classic.blockd.info"

--- a/params/bootnodes_classic.go
+++ b/params/bootnodes_classic.go
@@ -44,6 +44,6 @@ var ClassicBootnodes = []string{
 	"enode://fa64d1fcb2d4cd1d1606cb940ea2b69fee7dc6c7a85ac4ad05154df1e9ae9616a6a0fa67a59cb15f79346408efa5a4efeba1e5993ddbf4b5cedbda27644a61cf@47.91.30.48:30303",    //ETC Labs
 }
 
-var dnsPrefixETC = "enrtree://AJE62Q4DUX4QMMXEHCSSCSC65TDHZYSMONSD64P3WULVLSF6MRQ3K"
+var dnsPrefixETC = "enrtree://AJE62Q4DUX4QMMXEHCSSCSC65TDHZYSMONSD64P3WULVLSF6MRQ3K@"
 
 var ClassicDNSNetwork1 = dnsPrefixETC + "all.classic.blockd.info"

--- a/params/bootnodes_kotti.go
+++ b/params/bootnodes_kotti.go
@@ -24,3 +24,5 @@ var KottiBootnodes = []string{
 	"enode://e8a786a894db053fe6886e283fc4385389ad034e04a692a26335f30b714059efd5cead0e410ecd783ce095888fdafcc21a685f13501594e969d6f5ac7ba0388c@86.103.236.55:63384",
 	"enode://a59e33ccd2b3e52d578f1fbd70c6f9babda2650f0760d6ff3b37742fdcdfdb3defba5d56d315b40c46b70198c7621e63ffa3f987389c7118634b0fefbbdfa7fd@51.158.191.43:37956", // soc1c
 }
+
+var KottiDNSNetwork1 = dnsPrefixETC + "all.kotti.blockd.info"

--- a/params/bootnodes_mordor.go
+++ b/params/bootnodes_mordor.go
@@ -45,3 +45,5 @@ var MordorBootnodes = []string{
 	"enode://0fade975875f77237de433cba75893a09264e370d7c4d81a0a269d94ad01d9ebf6056f4d690e82f4fa636f02fee94b0393f6994919bb4cb275b26de352d40517@84.160.87.178:60648",
 	"enode://642cf9650dd8869d42525dbf6858012e3b4d64f475e733847ab6f7742341a4397414865d953874e8f5ed91b0e4e1c533dee14ad1d6bb276a5459b2471460ff0d@157.230.152.87:30303", // @meowsbits but don't count on it
 }
+
+var MordorDNSNetwork1 = dnsPrefixETC + "all.mordor.blockd.info"


### PR DESCRIPTION
rel #39 

Adds config defaults for nodeset command which allows filtering master ENR list for ETC networks.

Note that this change set uses the branch merging ethereum/go-ethereum@v1.9.11 as a base; that release is where this functionality is introduced.