### PR TITLE
params: ECIP1088 feature activation numbers

### DIFF
--- a/params/config_classic.go
+++ b/params/config_classic.go
@@ -59,20 +59,14 @@ var (
 		EIP1014FBlock: big.NewInt(9573000),
 		EIP1052FBlock: big.NewInt(9573000),
 
-		// Istanbul eq, aka Aztlan
-		// ECIP-1061
+		// Istanbul eq, aka Phoenix
+		// ECIP-1088
 		EIP152FBlock:  big.NewInt(10_500_839),
 		EIP1108FBlock: big.NewInt(10_500_839),
 		EIP1344FBlock: big.NewInt(10_500_839),
-		EIP1884FBlock: nil,
+		EIP1884FBlock: big.NewInt(10_500_839),
 		EIP2028FBlock: big.NewInt(10_500_839),
 		EIP2200FBlock: big.NewInt(10_500_839), // RePetersburg (=~ re-1283)
-
-		// ECIP-1078, aka Phoenix Fix
-		EIP2200DisableFBlock: nil, // big.NewInt(10_500_839)
-		EIP1283FBlock:        nil, // big.NewInt(10_500_839)
-		EIP1706FBlock:        nil, // big.NewInt(10_500_839)
-		ECIP1080FBlock:       nil, // big.NewInt(10_500_839)
 
 		DisposalBlock:      big.NewInt(5900000),
 		ECIP1017FBlock:     big.NewInt(5000000),

--- a/params/config_kotti.go
+++ b/params/config_kotti.go
@@ -62,20 +62,14 @@ var (
 		EIP1014FBlock: big.NewInt(1705549),
 		EIP1052FBlock: big.NewInt(1705549),
 
-		// Istanbul eq, aka Aztlan
-		// ECIP-1061
-		EIP152FBlock:  big.NewInt(2058191),
-		EIP1108FBlock: big.NewInt(2058191),
-		EIP1344FBlock: big.NewInt(2058191),
-		EIP1884FBlock: nil,
-		EIP2028FBlock: big.NewInt(2058191),
-		EIP2200FBlock: big.NewInt(2058191), // RePetersburg (== re-1283)
-
-		// ECIP-1078, aka Phoenix Fix
-		EIP2200DisableFBlock: big.NewInt(2_208_203),
-		EIP1283FBlock:        big.NewInt(2_208_203),
-		EIP1706FBlock:        big.NewInt(2_208_203),
-		ECIP1080FBlock:       big.NewInt(2_208_203),
+		// Istanbul eq, aka Phoenix
+		// ECIP-1088
+		EIP152FBlock:  big.NewInt(2_125_017),
+		EIP1108FBlock: big.NewInt(2_125_017),
+		EIP1344FBlock: big.NewInt(2_125_017),
+		EIP1884FBlock: big.NewInt(2_125_017),
+		EIP2028FBlock: big.NewInt(2_125_017),
+		EIP2200FBlock: big.NewInt(2_125_017), // RePetersburg (== re-1283)
 
 		ECIP1017FBlock:    big.NewInt(5000000),
 		ECIP1017EraRounds: big.NewInt(5000000),

--- a/params/config_kotti.go
+++ b/params/config_kotti.go
@@ -64,12 +64,12 @@ var (
 
 		// Istanbul eq, aka Phoenix
 		// ECIP-1088
-		EIP152FBlock:  big.NewInt(2_125_017),
-		EIP1108FBlock: big.NewInt(2_125_017),
-		EIP1344FBlock: big.NewInt(2_125_017),
-		EIP1884FBlock: big.NewInt(2_125_017),
-		EIP2028FBlock: big.NewInt(2_125_017),
-		EIP2200FBlock: big.NewInt(2_125_017), // RePetersburg (== re-1283)
+		EIP152FBlock:  big.NewInt(2_200_013),
+		EIP1108FBlock: big.NewInt(2_200_013),
+		EIP1344FBlock: big.NewInt(2_200_013),
+		EIP1884FBlock: big.NewInt(2_200_013),
+		EIP2028FBlock: big.NewInt(2_200_013),
+		EIP2200FBlock: big.NewInt(2_200_013), // RePetersburg (== re-1283)
 
 		ECIP1017FBlock:    big.NewInt(5000000),
 		ECIP1017EraRounds: big.NewInt(5000000),

--- a/params/config_mordor.go
+++ b/params/config_mordor.go
@@ -56,20 +56,14 @@ var (
 		EIP1014FBlock: big.NewInt(301243),
 		EIP1052FBlock: big.NewInt(301243),
 
-		// Istanbul eq, aka Aztlan
-		// ECIP-1061
-		EIP152FBlock:  big.NewInt(778507),
-		EIP1108FBlock: big.NewInt(778507),
-		EIP1344FBlock: big.NewInt(778507),
-		EIP1884FBlock: nil,
-		EIP2028FBlock: big.NewInt(778507),
-		EIP2200FBlock: big.NewInt(778507), // RePetersburg (== re-1283)
-
-		// ECIP-1078, aka Phoenix Fix
-		EIP2200DisableFBlock: big.NewInt(976_231),
-		EIP1283FBlock:        big.NewInt(976_231),
-		EIP1706FBlock:        big.NewInt(976_231),
-		ECIP1080FBlock:       big.NewInt(976_231),
+		// Istanbul eq, aka Phoenix
+		// ECIP-1088
+		EIP152FBlock:  big.NewInt(839_246),
+		EIP1108FBlock: big.NewInt(839_246),
+		EIP1344FBlock: big.NewInt(839_246),
+		EIP1884FBlock: big.NewInt(839_246),
+		EIP2028FBlock: big.NewInt(839_246),
+		EIP2200FBlock: big.NewInt(839_246), // RePetersburg (== re-1283)
 
 		DisposalBlock:      big.NewInt(0),
 		ECIP1017FBlock:     big.NewInt(0),

--- a/params/config_mordor.go
+++ b/params/config_mordor.go
@@ -58,12 +58,12 @@ var (
 
 		// Istanbul eq, aka Phoenix
 		// ECIP-1088
-		EIP152FBlock:  big.NewInt(839_246),
-		EIP1108FBlock: big.NewInt(839_246),
-		EIP1344FBlock: big.NewInt(839_246),
-		EIP1884FBlock: big.NewInt(839_246),
-		EIP2028FBlock: big.NewInt(839_246),
-		EIP2200FBlock: big.NewInt(839_246), // RePetersburg (== re-1283)
+		EIP152FBlock:  big.NewInt(999_983),
+		EIP1108FBlock: big.NewInt(999_983),
+		EIP1344FBlock: big.NewInt(999_983),
+		EIP1884FBlock: big.NewInt(999_983),
+		EIP2028FBlock: big.NewInt(999_983),
+		EIP2200FBlock: big.NewInt(999_983), // RePetersburg (== re-1283)
 
 		DisposalBlock:      big.NewInt(0),
 		ECIP1017FBlock:     big.NewInt(0),


### PR DESCRIPTION
> https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1088.md

The block numbers for Mordor and Kotti are still, AFAIU, somewhat unstable.

These initially proposed numbers (at https://github.com/etclabscore/core-geth/commit/cf93f231a9f331ec94e854891dff1a8ec05c173b) are taken from investigation via #38 to find the latest-viable numbers the chains can reach before the now-nullified Aztlan features would fork the networks.

