### PR TITLE
Fix/downloader logs and span search delta

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -854,7 +854,7 @@ func (d *Downloader) findAncestorSpanSearch(p *peerConnection, remoteHeight, loc
 	}
 	// If the head fetch already found an ancestor, return
 	if hash != (common.Hash{}) {
-		if int64(number) < floor {
+		if int64(number) <= floor {
 			p.log.Warn("Ancestor below allowance", "number", number, "hash", hash, "allowance", floor)
 			return 0, errInvalidAncestor
 		}
@@ -940,7 +940,7 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, remoteHeight ui
 		}
 	}
 	// Ensure valid ancestry and return
-	if int64(start) < floor {
+	if int64(start) <= floor {
 		p.log.Warn("Ancestor below allowance", "number", start, "hash", hash, "allowance", floor)
 		return 0, errInvalidAncestor
 	}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -854,7 +854,7 @@ func (d *Downloader) findAncestorSpanSearch(p *peerConnection, remoteHeight, loc
 	}
 	// If the head fetch already found an ancestor, return
 	if hash != (common.Hash{}) {
-		if int64(number) <= floor {
+		if int64(number) < floor {
 			p.log.Warn("Ancestor below allowance", "number", number, "hash", hash, "allowance", floor)
 			return 0, errInvalidAncestor
 		}
@@ -940,7 +940,7 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, remoteHeight ui
 		}
 	}
 	// Ensure valid ancestry and return
-	if int64(start) <= floor {
+	if int64(start) < floor {
 		p.log.Warn("Ancestor below allowance", "number", start, "hash", hash, "allowance", floor)
 		return 0, errInvalidAncestor
 	}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -904,17 +904,17 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, remoteHeight ui
 				arrived = true
 
 				// Modify the search interval based on the response
-				h := headers[0].Hash()
+				hash = headers[0].Hash()
 				n := headers[0].Number.Uint64()
 
 				var known bool
 				switch d.mode {
 				case FullSync:
-					known = d.blockchain.HasBlock(h, n)
+					known = d.blockchain.HasBlock(hash, n)
 				case FastSync:
-					known = d.blockchain.HasFastBlock(h, n)
+					known = d.blockchain.HasFastBlock(hash, n)
 				case LightSync:
-					known = d.lightchain.HasHeader(h, n)
+					known = d.lightchain.HasHeader(hash, n)
 				default:
 					log.Crit("unknown sync mode", "mode", d.mode)
 				}
@@ -922,13 +922,12 @@ func (d *Downloader) findAncestorBinarySearch(p *peerConnection, remoteHeight ui
 					end = check
 					break
 				}
-				header := d.lightchain.GetHeaderByHash(h) // Independent of sync mode, header surely exists
+				header := d.lightchain.GetHeaderByHash(hash) // Independent of sync mode, header surely exists
 				if header.Number.Uint64() != check {
 					p.log.Debug("Received non requested header", "number", header.Number, "hash", header.Hash(), "request", check)
 					return 0, errBadPeer
 				}
 				start = check
-				hash = h
 
 			case <-timeout:
 				p.log.Debug("Waiting for search header timed out", "elapsed", ttl)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -20,6 +20,7 @@ package downloader
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -753,7 +754,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 	}
 
 	// Only attempt span search if local head is "close" to reported remote
-	if remoteHeight-localHeight < uint64(MaxHeaderFetch) {
+	if math.Abs(float64(remoteHeight-localHeight)) < float64(MaxHeaderFetch) {
 		a, err := d.findAncestorSpanSearch(p, remoteHeight, localHeight, floor)
 		if err == nil {
 			if a > localHeight {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -683,8 +683,8 @@ func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	assertOwnChain(t, tester, chainA.len())
 
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
-	if err := tester.sync("rewriter", nil, mode); err != errInvalidChain {
-		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidChain)
+	if err := tester.sync("rewriter", nil, mode); err != errInvalidAncestor {
+		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
 	}
 }
 
@@ -717,8 +717,8 @@ func testBoundedHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	assertOwnChain(t, tester, chainA.len())
 
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
-	if err := tester.sync("heavy-rewriter", nil, mode); err != errInvalidChain {
-		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidChain)
+	if err := tester.sync("heavy-rewriter", nil, mode); err != errInvalidAncestor {
+		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
 	}
 }
 

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -683,8 +683,8 @@ func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	assertOwnChain(t, tester, chainA.len())
 
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
-	if err := tester.sync("rewriter", nil, mode); err != errInvalidAncestor {
-		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
+	if err := tester.sync("rewriter", nil, mode); err != errInvalidChain {
+		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidChain)
 	}
 }
 
@@ -717,8 +717,8 @@ func testBoundedHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	assertOwnChain(t, tester, chainA.len())
 
 	// Synchronise with the second peer and ensure that the fork is rejected to being too old
-	if err := tester.sync("heavy-rewriter", nil, mode); err != errInvalidAncestor {
-		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidAncestor)
+	if err := tester.sync("heavy-rewriter", nil, mode); err != errInvalidChain {
+		t.Fatalf("sync failure mismatch: have %v, want %v", err, errInvalidChain)
 	}
 }
 


### PR DESCRIPTION
- https://github.com/etclabscore/core-geth/pull/105/commits/69da528505e13262268ba7f44b2226f4397e1355 is the interesting one. 
  + https://github.com/ethereum/go-ethereum/blob/master/eth/downloader/downloader.go#L817
  + https://github.com/ethereum/go-ethereum/blob/master/eth/downloader/downloader.go#L896
  + `floor` assignment is the same: https://github.com/ethereum/go-ethereum/blob/master/eth/downloader/downloader.go#L722

Am I right? PTAL. 
If so, let's make this (or an equivalent) upstream as well.

(I noticed this because I was seeing logs like below.)

```txt
WARN [05-26|12:03:04.420] Ancestor below allowance                 peer=5ed95f530fa3a22f number=10374213 hash="000000…000000" allowance=10374213
WARN [05-26|12:03:06.537] Ancestor below allowance                 peer=caa60bff46c9af6f number=10374214 hash="000000…000000" allowance=10374214
WARN [05-26|12:07:23.664] Ancestor below allowance                 peer=17c9b12cc635e028 number=10374232 hash="000000…000000" allowance=10374232
WARN [05-26|12:08:16.442] Ancestor below allowance                 peer=b68f78d37eb4969f number=10374233 hash="000000…000000" allowance=10374233
WARN [05-26|12:11:33.612] Ancestor below allowance                 peer=596ba8ce636ce66a number=10374242 hash="000000…000000" allowance=10374242
WARN [05-26|12:11:59.311] Ancestor below allowance                 peer=caa60bff46c9af6f number=10374242 hash="000000…000000" allowance=10374242
WARN [05-26|12:12:16.996] Ancestor below allowance                 peer=596ba8ce636ce66a number=10374243 hash="000000…000000" allowance=10374243
WARN [05-26|12:14:02.252] Ancestor below allowance                 peer=8e0933d8d44ea192 number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:14:04.845] Ancestor below allowance                 peer=9efb8b5c696f49ce number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:14:09.445] Ancestor below allowance                 peer=ff4075b6eb686d01 number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:14:32.119] Ancestor below allowance                 peer=ef387cf6e82f1cb7 number=10374250 hash="000000…000000" allowance=10374250
WARN [05-26|12:15:22.371] Ancestor below allowance                 peer=a21229182f495487 number=10374251 hash="000000…000000" allowance=10374251
WARN [05-26|12:15:43.180] Ancestor below allowance                 peer=1cdbc3b2caeafc90 number=10374253 hash="000000…000000" allowance=10374253
WARN [05-26|12:15:52.322] Ancestor below allowance                 peer=ac7bf025c6d8bbd9 number=10374253 hash="000000…000000" allowance=10374253
WARN [05-26|12:15:52.549] Ancestor below allowance                 peer=5ed95f530fa3a22f number=10374253 hash="000000…000000" allowance=10374253
WARN [05-26|12:16:13.737] Ancestor below allowance                 peer=4dc523d87212135b number=10374253 hash="000000…000000" allowance=10374253
WARN [05-26|12:16:14.852] Ancestor below allowance                 peer=028b7b068e670d50 number=10374254 hash="000000…000000" allowance=10374254
WARN [05-26|12:17:33.813] Ancestor below allowance                 peer=e9faf4e40b8c9374 number=10374257 hash="000000…000000" allowance=10374257
WARN [05-26|12:19:25.091] Ancestor below allowance                 peer=24a521c582287f27 number=10374267 hash="000000…000000" allowance=10374267
WARN [05-26|12:22:38.528] Ancestor below allowance                 peer=4dc523d87212135b number=10374283 hash="000000…000000" allowance=10374283
```