### PR TITLE
utils,console: allow --datadir='' to use memory database

### DIFF
--- a/cmd/utils/customflags.go
+++ b/cmd/utils/customflags.go
@@ -196,6 +196,9 @@ func expandPath(p string) string {
 			p = home + p[1:]
 		}
 	}
+	if p == "" {
+		return p
+	}
 	return path.Clean(os.ExpandEnv(p))
 }
 

--- a/cmd/utils/customflags_test.go
+++ b/cmd/utils/customflags_test.go
@@ -30,6 +30,7 @@ func TestPathExpansion(t *testing.T) {
 		"~thisOtherUser/b/":  "~thisOtherUser/b",
 		"$DDDXXX/a/b":        "/tmp/a/b",
 		"/a/b/":              "/a/b",
+		"":                   "",
 	}
 	os.Setenv("DDDXXX", "/tmp")
 	for test, expected := range tests {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -773,7 +773,9 @@ func MakeDataDir(ctx *cli.Context) string {
 		}
 		return dataDirPathForCtxChainConfig(ctx, path)
 	}
-	Fatalf("Cannot determine default data directory, please set manually (--%s)", DataDirFlag.Name)
+	if !ctx.GlobalIsSet(DataDirFlag.Name) {
+		Fatalf("Cannot determine default data directory, please set manually (--%s)", DataDirFlag.Name)
+	}
 	return ""
 }
 
@@ -1322,7 +1324,9 @@ func dataDirPathForCtxChainConfig(ctx *cli.Context, baseDataDirPath string) stri
 func setDataDir(ctx *cli.Context, cfg *node.Config) {
 	switch {
 	case ctx.GlobalIsSet(DataDirFlag.Name):
-		cfg.DataDir = ctx.GlobalString(DataDirFlag.Name)
+		val := ctx.GlobalString(DataDirFlag.Name)
+		log.Info("Using custom datadir", "dir", val)
+		cfg.DataDir = val
 
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		cfg.DataDir = "" // unless explicitly requested, use memory databases


### PR DESCRIPTION
Geth is capable of using an in-memory based datastore, which, for example, is used as the default for the `--dev` mode.

The existing functionality of `--datadir=''` caused geth to use the current working director y (`.`) as its data directory, while an empty value for that configuration parameter in most of the code causes the node use the in-mem db. 

I'm not sure if this is intentional or a bug, but it seemed counterintuitive to me. Indeed, using an in-memory db for normal operations is rather _avant garde_, but it does not seem to me as though it should be disallowed with an unexplained override to the current directory.

This change set modifies `--datadir` to use the empty value as an effective signal for geth to use the in-memory db setting instead of the current directory.

Based on #112 