### PR TITLE
Release/v1.11.6

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 11       // Minor version component of the current release
-	VersionPatch = 6        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 11         // Minor version component of the current release
+	VersionPatch = 7          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 11         // Minor version component of the current release
-	VersionPatch = 6          // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 11       // Minor version component of the current release
+	VersionPatch = 6        // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
- __Merges__ ethereum/go-ethereum through [v1.9.15](https://github.com/ethereum/go-ethereum/releases/tag/v1.9.15)
  + __Adds__ support for YoloV1 testnet, including EIP2537 (BLS precompiles)
  + __Adds__ code for EIP2315, though not yet user-facing
- __Fixes__ Kotti `forkid` configuration
