### PR TITLE
improve cross-consensus engine tests and interface implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ test-coregeth-features-parity:
 	env COREGETH_TESTS_CHAINCONFIG_FEATURE_EQUIVALENCE_OPENETHEREUM=on go test -count=1 ./tests
 
 test-coregeth-features-coregeth:
-	@echo "Testing fork/feature/datatype implementation; equivalence - MULTIGETH."
-	env COREGETH_TESTS_CHAINCONFIG_FEATURE_EQUIVALENCE_MULTIGETH=on go test -count=1 ./tests
+	@echo "Testing fork/feature/datatype implementation; equivalence - COREGETH."
+	env COREGETH_TESTS_CHAINCONFIG_FEATURE_EQUIVALENCE_COREGETH=on go test -count=1 ./tests
 
 test-coregeth-features-multigethv0:
 	@echo "Testing fork/feature/datatype implementation; equivalence - MULTIGETHv0."

--- a/params/types/coregeth/chain_config_configurator.go
+++ b/params/types/coregeth/chain_config_configurator.go
@@ -427,9 +427,11 @@ func (c *CoreGethChainConfig) MustSetConsensusEngineType(t ctypes.ConsensusEngin
 	switch t {
 	case ctypes.ConsensusEngineT_Ethash:
 		c.Ethash = new(ctypes.EthashConfig)
+		c.Clique = nil
 		return nil
 	case ctypes.ConsensusEngineT_Clique:
 		c.Clique = new(ctypes.CliqueConfig)
+		c.Ethash = nil
 		return nil
 	default:
 		return ctypes.ErrUnsupportedConfigFatal

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -434,9 +434,11 @@ func (c *ChainConfig) MustSetConsensusEngineType(t ctypes.ConsensusEngineT) erro
 	switch t {
 	case ctypes.ConsensusEngineT_Ethash:
 		c.Ethash = new(ctypes.EthashConfig)
+		c.Clique = nil
 		return nil
 	case ctypes.ConsensusEngineT_Clique:
 		c.Clique = new(ctypes.CliqueConfig)
+		c.Ethash = nil
 		return nil
 	default:
 		return ctypes.ErrUnsupportedConfigFatal

--- a/params/types/multigethv0/multigethv0_chain_config_configurator.go
+++ b/params/types/multigethv0/multigethv0_chain_config_configurator.go
@@ -439,9 +439,11 @@ func (c *ChainConfig) MustSetConsensusEngineType(t ctypes.ConsensusEngineT) erro
 	switch t {
 	case ctypes.ConsensusEngineT_Ethash:
 		c.Ethash = new(ctypes.EthashConfig)
+		c.Clique = nil
 		return nil
 	case ctypes.ConsensusEngineT_Clique:
 		c.Clique = new(ctypes.CliqueConfig)
+		c.Ethash = nil
 		return nil
 	default:
 		return ctypes.ErrUnsupportedConfigFatal

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -532,17 +532,29 @@ func (spec *ParityChainSpec) GetConsensusEngineType() ctypes.ConsensusEngineT {
 }
 
 func (spec *ParityChainSpec) MustSetConsensusEngineType(t ctypes.ConsensusEngineT) error {
+	var err error
 	switch t {
 	case ctypes.ConsensusEngineT_Ethash:
 		if spec.GetEthashMinimumDifficulty() == nil {
-			spec.SetEthashMinimumDifficulty(vars.MinimumDifficulty)
+			err = spec.SetEthashMinimumDifficulty(vars.MinimumDifficulty)
+			if err != nil {
+				return err
+			}
 		}
+		spec.Engine.Clique.Params.Period = nil
 		return nil
 	case ctypes.ConsensusEngineT_Clique:
 		if spec.Engine.Clique.Params.Period == nil {
-			spec.SetCliqueEpoch(30000)
-			spec.SetCliquePeriod(0)
+			err = spec.SetCliqueEpoch(30000)
+			if err != nil {
+				return err
+			}
+			err = spec.SetCliquePeriod(0)
+			if err != nil {
+				return err
+			}
 		}
+		spec.Engine.Ethash.Params.MinimumDifficulty = nil
 		return nil
 	default:
 		return ctypes.ErrUnsupportedConfigFatal
@@ -555,6 +567,7 @@ func (spec *ParityChainSpec) GetEthashMinimumDifficulty() *big.Int {
 
 func (spec *ParityChainSpec) SetEthashMinimumDifficulty(n *big.Int) error {
 	if n == nil {
+		spec.Engine.Ethash.Params.MinimumDifficulty = nil
 		return nil
 	}
 	spec.Engine.Ethash.Params.MinimumDifficulty = math.NewHexOrDecimal256(n.Int64())

--- a/tests/params.go
+++ b/tests/params.go
@@ -201,20 +201,27 @@ func init() {
 	} else if os.Getenv(CG_CHAINCONFIG_CONSENSUS_EQ_CLIQUE) != "" {
 		log.Println("converting Istanbul config to Clique consensus engine")
 
-		c := Forks["Istanbul"]
-		err := c.MustSetConsensusEngineType(ctypes.ConsensusEngineT_Clique)
-		if err != nil {
-			log.Fatal(err)
+		for _, c := range Forks {
+			if c.GetConsensusEngineType().IsEthash() {
+				err := c.MustSetConsensusEngineType(ctypes.ConsensusEngineT_Clique)
+				if err != nil {
+					log.Fatal(err)
+				}
+				err = c.SetCliqueEpoch(30000)
+				if err != nil {
+					log.Fatal(err)
+				}
+				err = c.SetCliquePeriod(15)
+				if err != nil {
+					log.Fatal(err)
+				}
+			} else if c.GetConsensusEngineType().IsClique() {
+				err := c.MustSetConsensusEngineType(ctypes.ConsensusEngineT_Ethash)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
 		}
-		err = c.SetCliqueEpoch(30000)
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = c.SetCliquePeriod(15)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 	}
 }
 


### PR DESCRIPTION
- fix typo in Makefile command
- test all chain configuration using alternate consensus engine with `TestState` of the test/ suite.
- all chain configurator implementations allow only one enabled consensus engine at a time