### PR TITLE
downloader: handle light sync case as findAncestor condition

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -459,10 +459,8 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 
 	var origin = uint64(0)
 
-	if d.blockchain != nil &&
-		d.blockchain.CurrentHeader() != nil &&
-		d.blockchain.CurrentHeader().Number != nil &&
-		d.blockchain.CurrentHeader().Number.Uint64() > 0 {
+	if (d.mode != LightSync && d.blockchain.CurrentHeader().Number.Uint64() > 0) ||
+		d.lightchain.CurrentHeader().Number.Uint64() > 0 {
 		origin, err = d.findAncestor(p, latest)
 		if err != nil {
 			return err


### PR DESCRIPTION
In addition to being quite terribly ugly, this
condition set erroneously excluded the light sync
case entirely.

This change handles d._chain cases depending on
respective sync modes, and fixes the case that
light sync mode would never actually use the
findAncestor negotiations.

The original code was introduced via 
https://github.com/etclabscore/core-geth/pull/78/commits/23cc3fa4cd1d39033eca8aa5ab7541a292b00d50 at https://github.com/etclabscore/core-geth/pull/78.