### PR TITLE
main,utils,exp: enable stand-alone metrics server from pprof

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -88,6 +88,8 @@ The dumpgenesis command dumps the genesis block configuration in JSON format to 
 			utils.CacheGCFlag,
 			utils.MetricsEnabledFlag,
 			utils.MetricsEnabledExpensiveFlag,
+			utils.MetricsHTTPFlag,
+			utils.MetricsPortFlag,
 			utils.MetricsEnableInfluxDBFlag,
 			utils.MetricsInfluxDBEndpointFlag,
 			utils.MetricsInfluxDBDatabaseFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -208,6 +208,8 @@ var (
 	metricsFlags = []cli.Flag{
 		utils.MetricsEnabledFlag,
 		utils.MetricsEnabledExpensiveFlag,
+		utils.MetricsHTTPFlag,
+		utils.MetricsPortFlag,
 		utils.MetricsEnableInfluxDBFlag,
 		utils.MetricsInfluxDBEndpointFlag,
 		utils.MetricsInfluxDBDatabaseFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -51,6 +51,7 @@ import (
 	"github.com/ethereum/go-ethereum/les"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/metrics/exp"
 	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/node"
@@ -713,6 +714,21 @@ var (
 	MetricsEnabledExpensiveFlag = cli.BoolFlag{
 		Name:  "metrics.expensive",
 		Usage: "Enable expensive metrics collection and reporting",
+	}
+
+	// MetricsHTTPFlag defines the endpoint for a stand-alone metrics HTTP endpoint.
+	// Since the pprof service enables sensitive/vulnerable behavior, this allows a user
+	// to enable a public-OK metrics endpoint without having to worry about ALSO exposing
+	// other profiling behavior or information.
+	MetricsHTTPFlag = cli.StringFlag{
+		Name:  "metrics.addr",
+		Usage: "Enable stand-alone metrics HTTP server listening interface",
+		Value: "127.0.0.1",
+	}
+	MetricsPortFlag = cli.IntFlag{
+		Name:  "metrics.port",
+		Usage: "Metrics HTTP server listening port",
+		Value: 6060,
 	}
 	MetricsEnableInfluxDBFlag = cli.BoolFlag{
 		Name:  "metrics.influxdb",
@@ -1806,6 +1822,7 @@ func RegisterGraphQLService(stack *node.Node, endpoint string, cors, vhosts []st
 func SetupMetrics(ctx *cli.Context) {
 	if metrics.Enabled {
 		log.Info("Enabling metrics collection")
+
 		var (
 			enableExport = ctx.GlobalBool(MetricsEnableInfluxDBFlag.Name)
 			endpoint     = ctx.GlobalString(MetricsInfluxDBEndpointFlag.Name)
@@ -1820,6 +1837,12 @@ func SetupMetrics(ctx *cli.Context) {
 			log.Info("Enabling metrics export to InfluxDB")
 
 			go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "geth.", tagsMap)
+		}
+
+		if ctx.GlobalIsSet(MetricsHTTPFlag.Name) {
+			address := fmt.Sprintf("%s:%d", ctx.GlobalString(MetricsHTTPFlag.Name), ctx.GlobalInt(MetricsPortFlag.Name))
+			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
+			exp.Setup(address)
 		}
 	}
 }

--- a/metrics/exp/exp.go
+++ b/metrics/exp/exp.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/metrics/prometheus"
 )
@@ -50,6 +51,20 @@ func Exp(r metrics.Registry) {
 func ExpHandler(r metrics.Registry) http.Handler {
 	e := exp{sync.Mutex{}, r}
 	return http.HandlerFunc(e.expHandler)
+}
+
+// Setup starts a dedicated metrics server at the given address.
+// This function enables metrics reporting separate from pprof.
+func Setup(address string) {
+	m := http.NewServeMux()
+	m.Handle("/debug/metrics", ExpHandler(metrics.DefaultRegistry))
+	m.Handle("/debug/metrics/prometheus", prometheus.Handler(metrics.DefaultRegistry))
+	log.Info("Starting metrics server", "addr", fmt.Sprintf("http://%s/debug/metrics", address))
+	go func() {
+		if err := http.ListenAndServe(address, m); err != nil {
+			log.Error("Failure in running metrics server", "err", err)
+		}
+	}()
 }
 
 func (exp *exp) getInt(name string) *expvar.Int {

--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -114,7 +114,7 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 	}
 
 	if config.PprofAddress != "" {
-		debug.StartPProf(config.PprofAddress)
+		debug.StartPProf(config.PprofAddress, true)
 	}
 
 	// Create the empty networking stack


### PR DESCRIPTION
ExpVar and Prometheus metrics endpoints were bundled and dependent with `--pprof`.

Since [`--pprof` exposes sensitive/vulnerable behavior](https://blog.ethereum.org/2019/07/10/geth-v1-9-0/#metrics-collection), this change allows the user the configure a metrics endpoint independent of the pprof endpoint.

Adds the following flags:

```go
	// MetricsHTTPFlag defines the endpoint for a stand-alone metrics HTTP endpoint.
	// Since the pprof service enables sensitive/vulnerable behavior, this allows a user
	// to enable a public-OK metrics endpoint without having to worry about ALSO exposing
	// other profiling behavior or information.
	MetricsHTTPFlag = cli.StringFlag{
		Name: "metrics.addr",
		Usage: "Enable stand-alone metrics HTTP server listening interface",
		Value: "127.0.0.1",
	}
	MetricsPortFlag = cli.IntFlag{
		Name: "metrics.port",
		Usage: "Metrics HTTP server listening port",
		Value: 6060,
	}
```

Use:

```sh
# Keeps previous behavior; exposes 
# - http://127.0.0.1:6060/debug/pprof 
# - http://127.0.0.1:6060/debug/metrics
# - http://127.0.0.1:6060/debug/metrics/prometheus
> geth --pprof --metrics

# Keeps previous behavior; exposes 
# - http://0.0.0.0:8080/debug/pprof 
# - http://0.0.0.0:8080/debug/metrics
# - http://0.0.0.0:8080/debug/metrics/prometheus
> geth --pprof --pprof.addr=0.0.0.0 --pprof.port=8080 --metrics

# Enables separated behavior; exposes 
# - http://127.0.0.1:6060/debug/pprof 
# - http://0.0.0.0:8080/debug/metrics
# - http://0.0.0.0:8080/debug/metrics/prometheus
> geth --pprof [--pprof.addr=127.0.0.1 (default)] --metrics --metrics.addr=0.0.0.0 --metrics.port=8080

# Enables stand-alone behavior; exposes 
# - http://0.0.0.0:8080/debug/metrics
# - http://0.0.0.0:8080/debug/metrics/prometheus
> geth --metrics --metrics.addr=0.0.0.0 --metrics.port=8080

# Colliding endpoints will cause the metrics endpoint to fail,and an ERROR message to be logged
> geth --pprof --metrics --metrics.addr=0.0.0.0
INFO [07-02|10:45:49.796] Starting pprof server                    addr=http://127.0.0.1:6060/debug/pprof
INFO [07-02|10:45:49.796] Starting Geth on Ethereum mainnet...
INFO [07-02|10:45:49.796] Bumping default cache on mainnet         provided=1024 updated=4096
INFO [07-02|10:45:49.796] Enabling metrics collection
INFO [07-02|10:45:49.797] Enabling stand-alone metrics HTTP endpoint address=0.0.0.0:6060
INFO [07-02|10:45:49.797] Starting metrics server                  addr=http://0.0.0.0:6060/debug/metrics
ERROR[07-02|10:45:49.797] Failure in running metrics server        err="listen tcp 0.0.0.0:6060: bind: address already in use"
```