### PR TITLE
use #!/bin/sh shebangs to improve portability

### DIFF
--- a/build/evmone.sh
+++ b/build/evmone.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/build/hera.sh
+++ b/build/hera.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/build/ssvm.sh
+++ b/build/ssvm.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
Makes these scripts, which are used just for testing, POSIX-compliant and more portable.

Some docker containers, eg. alpine, dont
have bash, so this solves that.
