### PR TITLE
main,utils,node,rpc: install --ipc.chmod flag enabling set octal permissions for ipc path

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -33,6 +33,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -239,6 +240,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.HTTPVirtualHostsFlag,
 			utils.IPCDisabledFlag,
 			utils.IPCPathFlag,
+			utils.IPCChmodFlag,
 			utils.HTTPEnabledFlag,
 			rpcPortFlag,
 			signerSecretFlag,
@@ -703,7 +705,12 @@ func signer(c *cli.Context) error {
 	if !c.GlobalBool(utils.IPCDisabledFlag.Name) {
 		givenPath := c.GlobalString(utils.IPCPathFlag.Name)
 		ipcapiURL = ipcEndpoint(filepath.Join(givenPath, "clef.ipc"), configDir)
-		listener, _, err := rpc.StartIPCEndpoint(ipcapiURL, rpcAPI)
+		givenMode := c.GlobalString(utils.IPCChmodFlag.Name)
+		parsedMode, err := strconv.ParseUint(givenMode, 8, 32)
+		if err != nil {
+			utils.Fatalf("Could not parse IPC file mode: %v", err)
+		}
+		listener, _, err := rpc.StartIPCEndpoint(ipcapiURL, os.FileMode(parsedMode), rpcAPI)
 		if err != nil {
 			utils.Fatalf("Could not start IPC api: %v", err)
 		}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -195,6 +195,7 @@ var (
 		utils.LegacyWSAllowedOriginsFlag,
 		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
+		utils.IPCChmodFlag,
 		utils.InsecureUnlockAllowedFlag,
 		utils.RPCGlobalGasCap,
 		utils.RPCGlobalTxFeeCap,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -135,6 +135,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 		Flags: []cli.Flag{
 			utils.IPCDisabledFlag,
 			utils.IPCPathFlag,
+			utils.IPCChmodFlag,
 			utils.HTTPEnabledFlag,
 			utils.HTTPListenAddrFlag,
 			utils.HTTPPortFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -503,6 +503,11 @@ var (
 		Name:  "ipcpath",
 		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
 	}
+	IPCChmodFlag = cli.StringFlag{
+		Name:  "ipc.chmod",
+		Usage: "Specify octal value for ipc socket permissions",
+		Value: "0600",
+	}
 	HTTPEnabledFlag = cli.BoolFlag{
 		Name:  "http",
 		Usage: "Enable the HTTP-RPC server",
@@ -1035,12 +1040,18 @@ func setWS(ctx *cli.Context, cfg *node.Config) {
 // returning an empty string if IPC was explicitly disabled, or the set path.
 func setIPC(ctx *cli.Context, cfg *node.Config) {
 	CheckExclusive(ctx, IPCDisabledFlag, IPCPathFlag)
+	CheckExclusive(ctx, IPCDisabledFlag, IPCChmodFlag)
 	switch {
 	case ctx.GlobalBool(IPCDisabledFlag.Name):
 		cfg.IPCPath = ""
 	case ctx.GlobalIsSet(IPCPathFlag.Name):
 		cfg.IPCPath = ctx.GlobalString(IPCPathFlag.Name)
 	}
+	mode, err := strconv.ParseUint(ctx.GlobalString(IPCChmodFlag.Name), 8, 32)
+	if err != nil {
+		Fatalf("Could not parse IPC mode: %v", err)
+	}
+	cfg.IPCMode = os.FileMode(mode)
 }
 
 // setLes configures the les server and ultra light client settings from the command line flags.

--- a/node/config.go
+++ b/node/config.go
@@ -105,6 +105,9 @@ type Config struct {
 	// relative), then that specific path is enforced. An empty path disables IPC.
 	IPCPath string
 
+	// IPCMode is the octal file permissions for the IPC endpoint. Default is 0600.
+	IPCMode os.FileMode
+
 	// HTTPHost is the host interface on which to start the HTTP RPC server. If this
 	// field is empty, no HTTP API endpoint will be started.
 	HTTPHost string
@@ -217,6 +220,14 @@ func (c *Config) IPCEndpoint() string {
 		return filepath.Join(c.DataDir, c.IPCPath)
 	}
 	return c.IPCPath
+}
+
+// IPCChmod returns the configuration ipc file mode or default 0600 (-rw-------).
+func (c *Config) IPCChmod() os.FileMode {
+	if c.IPCMode == 0 {
+		return os.FileMode(0600)
+	}
+	return c.IPCMode
 }
 
 // NodeDB returns the path to the discovery node database.

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -573,7 +573,7 @@ func ipcTestClient(srv *Server, fl *flakeyListener) (*Client, net.Listener) {
 	} else {
 		endpoint = os.TempDir() + "/" + endpoint
 	}
-	l, err := ipcListen(endpoint)
+	l, err := ipcListen(endpoint, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/rpc/endpoints.go
+++ b/rpc/endpoints.go
@@ -18,12 +18,13 @@ package rpc
 
 import (
 	"net"
+	"os"
 
 	"github.com/ethereum/go-ethereum/log"
 )
 
 // StartIPCEndpoint starts an IPC endpoint.
-func StartIPCEndpoint(ipcEndpoint string, apis []API) (net.Listener, *Server, error) {
+func StartIPCEndpoint(ipcEndpoint string, ipcMode os.FileMode, apis []API) (net.Listener, *Server, error) {
 	// Register all the APIs exposed by the services.
 	handler := NewServer()
 	for _, api := range apis {
@@ -33,7 +34,7 @@ func StartIPCEndpoint(ipcEndpoint string, apis []API) (net.Listener, *Server, er
 		log.Debug("IPC registered", "namespace", api.Namespace)
 	}
 	// All APIs registered, start the IPC listener.
-	listener, err := ipcListen(ipcEndpoint)
+	listener, err := ipcListen(ipcEndpoint, ipcMode)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rpc/ipc_unix.go
+++ b/rpc/ipc_unix.go
@@ -29,7 +29,7 @@ import (
 )
 
 // ipcListen will create a Unix socket on the given endpoint.
-func ipcListen(endpoint string) (net.Listener, error) {
+func ipcListen(endpoint string, mode os.FileMode) (net.Listener, error) {
 	if len(endpoint) > int(max_path_size) {
 		log.Warn(fmt.Sprintf("The ipc endpoint is longer than %d characters. ", max_path_size),
 			"endpoint", endpoint)
@@ -44,7 +44,7 @@ func ipcListen(endpoint string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	os.Chmod(endpoint, 0600)
+	os.Chmod(endpoint, mode)
 	return l, nil
 }
 


### PR DESCRIPTION
Note that behavior is 'unique' on Windows, although
behavior there is unmodified, and at the users decision
(only owner r/w is set).

Resolves #143