### PR TITLE
vm: fix NewEVM to not always append additional EVM

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -149,9 +149,7 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig ctypes.ChainConfigurator, 
 	} else {
 		evm.interpreters = append(evm.interpreters, NewEVMInterpreter(evm, vmConfig))
 	}
-	// vmConfig.EVMInterpreter will be used by EVM-C, it won't be checked here
-	// as we always want to have the built-in EVM as the failover option.
-	evm.interpreters = append(evm.interpreters, NewEVMInterpreter(evm, vmConfig))
+
 	evm.interpreter = evm.interpreters[0]
 
 	return evm


### PR DESCRIPTION
The 'interpreters' field is initialized with size 2,
space for EVM and EWASM interpreters. There must always
be at least one interpreter available.

If the vmConfig.EVMInterpreter flag is nonempty, then
the external module will be used, else the built-in EVMInterpreter
will be used.

Without this change, if the user configures EWASM and EVM externally,
setup will attempt to append an additional interpreter, for which
there is not space assigned in the interpreters slice (size=2).

Signed-off-by: meows <b5c6@protonmail.com>