### PR TITLE
build/evmone.sh: fix superfluous evmone build dir

### DIFF
--- a/build/evmone.sh
+++ b/build/evmone.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-mkdir -p build/_workspace/evmone/build/tools/ssvm-evmc/
+mkdir -p build/_workspace/evmone
 wget -O build/_workspace/evmone/evmone-0.2.0-linux-x86_64.tar.gz https://github.com/ethereum/evmone/releases/download/v0.2.0/evmone-0.2.0-linux-x86_64.tar.gz
 tar xzvf build/_workspace/evmone/evmone-0.2.0-linux-x86_64.tar.gz -C build/_workspace/evmone/


### PR DESCRIPTION
This was just a spurious carry-over from copy-pasting
the script from ssvm.
It works fine because mkdir -p creates the base
path we need, but the extra children dirs are unnecessary.

Signed-off-by: meows <b5c6@protonmail.com>