### PR TITLE
Makefile,build/aleth-interpreter.sh: add additional test for EVMC using aleth interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,12 @@ test-coregeth: \
  test-coregeth-chainspecs \
  test-coregeth-consensus ## Runs all tests specific to core-geth.
 
+# Generate the necessary shared object for EVMC unit tests.
 evmc/bindings/go/evmc/example_vm.so:
 	./build/evmc-example_vm.so.sh
 
+# The following commands acquire external EWASM and EVM interpreter shared objects for
+# testing EVMC support.
 hera:
 	./build/hera.sh
 
@@ -57,14 +60,19 @@ ssvm:
 evmone:
 	./build/evmone.sh
 
-test-evmc: evmc/bindings/go/evmc/example_vm.so hera ssvm evmone
+aleth-interpreter:
+	./build/aleth-interpreter.sh
+
+# Test EVMC support against various external interpreters.
+test-evmc: evmc/bindings/go/evmc/example_vm.so hera ssvm evmone aleth-interpreter
 	go test -count 1 ./evmc/...
 	go test -count 1 ./tests -run TestState -evmc.ewasm=$(ROOT_DIR)/build/_workspace/hera/build/src/libhera.so
 	go test -count 1 ./tests -run TestState -evmc.ewasm=$(ROOT_DIR)/build/_workspace/SSVM/build/tools/ssvm-evmc/libssvmEVMC.so
 	go test -count 1 ./tests -run TestState -evmc.evm=$(ROOT_DIR)/build/_workspace/evmone/lib/libevmone.so
+	go test -count 1 ./tests -run TestState -evmc.evm=$(ROOT_DIR)/build/_workspace/aleth/lib/libaleth-interpreter.so
 
 clean-evmc:
-	rm -rf evmc/bindings/go/evmc/example_vm.so ./build/_workspace/hera ./build/_workspace/SSVM ./build/_workspace/evmone
+	rm -rf evmc/bindings/go/evmc/example_vm.so ./build/_workspace/hera ./build/_workspace/SSVM ./build/_workspace/evmone ./build/_workspace/aleth
 
 test-coregeth-features: test-coregeth-features-parity test-coregeth-features-coregeth test-coregeth-features-multigethv0 ## Runs tests specific to multi-geth using Fork/Feature configs.
 

--- a/build/aleth-interpreter.sh
+++ b/build/aleth-interpreter.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p build/_workspace/aleth
+wget -O build/_workspace/aleth/aleth-1.6.0-alpha.1-linux-x86_64.tar.gz https://github.com/ethereum/aleth/releases/download/v1.6.0-alpha.1/aleth-1.6.0-alpha.1-linux-x86_64.tar.gz
+tar xzvf build/_workspace/aleth/aleth-1.6.0-alpha.1-linux-x86_64.tar.gz -C build/_workspace/aleth/


### PR DESCRIPTION
This test was originally included with (or at least
adjacent to) original EVMC+go-ethereum integration plans.
https://github.com/ethereum/go-ethereum/pull/19176/files#diff-354f30a63fb0907d4ad57269548329e3R81

Signed-off-by: meows <b5c6@protonmail.com>