### PR TITLE
vm,vars: install SLOAD constantGas to eip2200

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -107,7 +107,7 @@ func opChainID(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx) ([
 
 // enable2200 applies EIP-2200 (Rebalance net-metered SSTORE)
 func enable2200(jt *JumpTable) {
-	// TODO(meowsbits): audit this
+	jt[SLOAD].constantGas = vars.SloadGasEIP2200
 	jt[SSTORE].dynamicGas = gasSStoreEIP2200
 }
 

--- a/params/vars/protocol_params.go
+++ b/params/vars/protocol_params.go
@@ -103,11 +103,11 @@ var (
 	ExtcodeSizeGasEIP150         uint64 = 700 // Cost of EXTCODESIZE after EIP 150 (Tangerine)
 	SloadGasFrontier             uint64 = 50
 	SloadGasEIP150               uint64 = 200
-	SloadGasEIP1884              uint64 = 800  // Cost of SLOAD after EIP 1884 (part of Istanbul)
-	SloadGasEIP2200              uint64 = 800  // Cost of SLOAD after EIP 2200 (part of Istanbul)
-	ExtcodeHashGasConstantinople uint64 = 400  // Cost of EXTCODEHASH (introduced in Constantinople)
-	ExtcodeHashGasEIP1884        uint64 = 700  // Cost of EXTCODEHASH after EIP 1884 (part in Istanbul)
-	SelfdestructGasEIP150        uint64 = 5000 // Cost of SELFDESTRUCT post EIP 150 (Tangerine)
+	SloadGasEIP1884              uint64 = 800             // Cost of SLOAD after EIP 1884 (part of Istanbul)
+	SloadGasEIP2200              uint64 = SloadGasEIP1884 // Cost of SLOAD after EIP 2200 (part of Istanbul).
+	ExtcodeHashGasConstantinople uint64 = 400             // Cost of EXTCODEHASH (introduced in Constantinople)
+	ExtcodeHashGasEIP1884        uint64 = 700             // Cost of EXTCODEHASH after EIP 1884 (part in Istanbul)
+	SelfdestructGasEIP150        uint64 = 5000            // Cost of SELFDESTRUCT post EIP 150 (Tangerine)
 
 	// EXP has a dynamic portion depending on the size of the exponent
 	ExpByteFrontier uint64 = 10 // was set to 10 in Frontier


### PR DESCRIPTION
Whether on not EIP2200 specifies SLOAD constant gas is a matter of interpretation and contention.
The document presumes the simultaneity of 1884, but does not do so explicitly.

However, EIP2200's engineering DOES NEED the SLOAD constant gas at 800, whether it clearly specifies it or not.
Please see https://github.com/etclabscore/core-geth/issues/35 as a starting point for reading through some of the history
here.

For all networks supported, and theoretically all networks properly using 2200,
__this change is a no-op__; since 2200 MUST be accompanied by 1884. 

The reason for this change is to make the code the same as ethereum/go-ethereum,
eliminating recurring merge conflicts that raise eyebrows.

Signed-off-by: meows <b5c6@protonmail.com>