### PR TITLE
Feat/gardening 20200727

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ sync-parity-chainspecs:
 	./params/parity.json.d/sync-parity-remote.sh
 
 test-coregeth: \
- test-coregeth-regression-condensed \
  test-coregeth-features \
  test-coregeth-chainspecs \
- test-coregeth-consensus ## Runs all tests specific to core-geth.
+ test-coregeth-consensus \
+ test-coregeth-regression-condensed ## Runs all tests specific to core-geth.
 
 # Generate the necessary shared object for EVMC unit tests.
 evmc/bindings/go/evmc/example_vm.so:

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -57,6 +57,7 @@ func TestConsoleCmdNetworkIdentities(t *testing.T) {
 
 		// All other possible --<chain> values.
 		{[]string{"--testnet"}, 3, 3, params.RopstenGenesisHash.Hex()},
+		{[]string{"--ropsten"}, 3, 3, params.RopstenGenesisHash.Hex()},
 		{[]string{"--rinkeby"}, 4, 4, params.RinkebyGenesisHash.Hex()},
 		{[]string{"--goerli"}, 5, 5, params.GoerliGenesisHash.Hex()},
 		{[]string{"--kotti"}, 6, 6, params.KottiGenesisHash.Hex()},

--- a/params/confp/configurator.go
+++ b/params/confp/configurator.go
@@ -98,8 +98,8 @@ func IsEmpty(anything interface{}) bool {
 func IsValid(conf ctypes.ChainConfigurator, head *uint64) *ConfigValidError {
 
 	// head-agnostic logic
-	if conf.GetNetworkID() == nil || *conf.GetNetworkID() == 0 {
-		return NewValidErr("NetworkID cannot be empty nor zero", ">=0", conf.GetNetworkID())
+	if conf.GetNetworkID() == nil {
+		return NewValidErr("NetworkID cannot be nil", "!=nil", conf.GetNetworkID())
 	}
 	if head == nil {
 		return nil


### PR DESCRIPTION
- (noop, code style): reorder commands in Makefile's `test-coregeth` command
- add chain identity test for `--ropsten` flag
- fix `echainspec validate` logic (used antiquated "geth" key)
- remove `confp.Validate` conditional testing NetworkID != 0; network id should be allowed to be 0, but not nil.