### PR TITLE
make evmc work with go mod

### DIFF
--- a/evmc/bindings/go/evmc/evmc.go
+++ b/evmc/bindings/go/evmc/evmc.go
@@ -5,7 +5,7 @@
 package evmc
 
 /*
-#cgo CFLAGS:  -I${SRCDIR}/.. -Wall -Wextra
+#cgo CFLAGS: -I${SRCDIR}/../../../include -Wall -Wextra
 #cgo !windows LDFLAGS: -ldl
 
 #include <evmc/evmc.h>

--- a/evmc/bindings/go/evmc/evmc.h
+++ b/evmc/bindings/go/evmc/evmc.h
@@ -1,1 +1,0 @@
-../../../include/evmc/evmc.h

--- a/evmc/bindings/go/evmc/helpers.h
+++ b/evmc/bindings/go/evmc/helpers.h
@@ -1,1 +1,0 @@
-../../../include/evmc/helpers.h

--- a/evmc/bindings/go/evmc/host.go
+++ b/evmc/bindings/go/evmc/host.go
@@ -5,7 +5,7 @@
 package evmc
 
 /*
-#cgo CFLAGS:  -I${SRCDIR}/.. -Wall -Wextra -Wno-unused-parameter
+#cgo CFLAGS: -I${SRCDIR}/../../../include -Wall -Wextra -Wno-unused-parameter
 
 #include <evmc/evmc.h>
 #include <evmc/helpers.h>

--- a/evmc/bindings/go/evmc/loader.c
+++ b/evmc/bindings/go/evmc/loader.c
@@ -1,1 +1,4 @@
-../../../lib/loader/loader.c
+/* Include evmc::loader in the Go package.
+ * The "go build" builds all additional C/C++ files in the Go package directory,
+ * but symbolic links are ignored so #include is used instead. */
+#include "../../../lib/loader/loader.c"

--- a/evmc/bindings/go/evmc/loader.h
+++ b/evmc/bindings/go/evmc/loader.h
@@ -1,1 +1,0 @@
-../../../include/evmc/loader.h


### PR DESCRIPTION
make evmc CFLAGS to use include dir

moving loader and header dependencies
to include/ dir, following steps
found here:
https://github.com/ethereum/evmc/commit/65d11a27876bbaa732ed1a22733873b882d133f7

This might help to resolve issue with
go mod working with core-geth as a
dependency.

Rel #160 

Signed-off-by: meows <b5c6@protonmail.com>