### PR TITLE
Release/v1.11.15

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 11       // Minor version component of the current release
-	VersionPatch = 15       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 11         // Minor version component of the current release
+	VersionPatch = 16         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 11         // Minor version component of the current release
-	VersionPatch = 15         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 11       // Minor version component of the current release
+	VersionPatch = 15       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
- Activates the artificial finality feature [MESS](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1100.md) on __Ethereum Classic Mainnet__ from block 11_380_000. 
- Merges upstream ethereum/go-ethereum through version [v1.9.22](https://github.com/ethereum/go-ethereum/releases/tag/v1.9.22). 
- Fixes issue parsing `--ethstats` url (#194)
- Activates [ECIP-1099](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1099.md) on _mordor_ at block 2_520_000
---

- Docker images published under [`etclabscore/core-geth`](https://hub.docker.com/r/etclabscore/core-geth/builds).