### PR TITLE
main,utils,core,eth: fixes --ecbp1100 flag use with default (ETH) config

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -20,10 +20,12 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"reflect"
 	"unicode"
 
+	"github.com/ethereum/go-ethereum/common/math"
 	cli "gopkg.in/urfave/cli.v1"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
@@ -161,6 +163,13 @@ func checkWhisper(ctx *cli.Context) {
 // makeFullNode loads geth configuration and creates the Ethereum backend.
 func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	stack, cfg := makeConfigNode(ctx)
+
+	// Handle cross-chain configuration override cases.
+	if ctx.GlobalIsSet(utils.ECBP1100Flag.Name) {
+		if n := ctx.GlobalUint64(utils.ECBP1100Flag.Name); n != math.MaxUint64 {
+			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
+		}
+	}
 
 	backend := utils.RegisterEthService(stack, &cfg.Eth)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/fdlimit"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -763,6 +764,7 @@ var (
 	ECBP1100Flag = cli.Uint64Flag{
 		Name:  "ecbp1100",
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
+		Value: math.MaxUint64,
 	}
 )
 
@@ -1705,13 +1707,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	// Override genesis configuration if a --<chain> flag.
 	if gen := genesisForCtxChainConfig(ctx); gen != nil {
 		cfg.Genesis = gen
-	}
-	// Handle temporary chain configuration override cases.
-	if ctx.GlobalIsSet(ECBP1100Flag.Name) {
-		n := ctx.GlobalUint64(ECBP1100Flag.Name)
-		if err := cfg.Genesis.Config.SetECBP1100Transition(&n); err != nil {
-			Fatalf("Failed to set ECBP-1100 activation number: %v", err)
-		}
 	}
 
 	// Establish NetworkID.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -131,7 +131,7 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.ECBP1100)
 	if _, ok := genesisErr.(*confp.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}

--- a/eth/config.go
+++ b/eth/config.go
@@ -189,4 +189,7 @@ type Config struct {
 
 	// CheckpointOracle is the configuration for checkpoint oracle.
 	CheckpointOracle *ctypes.CheckpointOracleConfig `toml:",omitempty"`
+
+	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
+	ECBP1100 *big.Int
 }


### PR DESCRIPTION
Fixes a panic caused by using `geth --ecbp1100=1`, which would enable ECBP1100 on ETH network. Panic was caused because of the "special" way the defaulty config is handled in app setup.

This implementation follows the pattern established at https://github.com/ethereum/go-ethereum/pull/20004/files, for example.

Note that the `SetupGenesisBlockWithOverride` method has to use the ecbp1100 condition twice. This is, again, because of workarounds core-geth has had to make to accomodate the ETH-as-default pattern established and perpetuated upstream, in compromise of not messing too much with the code to cause repetitive conflicts.

Maybe we can address this inelegance later, but for now, this should resolve the issue for all supported networks.

Note also that the ETH-config `String` method doesn't support ECBP1100 configuration printing because the data type does not natively support the value. This may also be addressed later, but is not critical.

Signed-off-by: meows <b5c6@protonmail.com>