### PR TITLE
miner: exit loop when downloader Done or Failed

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -112,8 +112,6 @@ func (miner *Miner) update() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}
-				// stop immediately and ignore all further pending events
-				return
 			}
 		case addr := <-miner.startCh:
 			if canStart {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -107,7 +107,6 @@ func (miner *Miner) update() {
 					log.Info("Mining aborted due to sync")
 				}
 			case downloader.DoneEvent, downloader.FailedEvent:
-				canStart = true
 				if shouldStart {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -112,6 +112,8 @@ func (miner *Miner) update() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}
+				// stop immediately and ignore all further pending events
+				return
 			}
 		case addr := <-miner.startCh:
 			if canStart {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -88,7 +88,8 @@ func (miner *Miner) update() {
 	events := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
 	defer events.Unsubscribe()
 
-	shouldStart := false
+	downloaderCanStop := true
+	miningRequested := false
 	canStart := true
 	for {
 		select {
@@ -98,17 +99,26 @@ func (miner *Miner) update() {
 			}
 			switch ev.Data.(type) {
 			case downloader.StartEvent:
-				wasMining := miner.Mining()
-				miner.worker.stop()
-				canStart = false
-				if wasMining {
-					// Resume mining after sync was finished
-					shouldStart = true
-					log.Info("Mining aborted due to sync")
+				if downloaderCanStop {
+					wasMining := miner.Mining()
+					miner.worker.stop()
+					canStart = false
+					if wasMining {
+						// Resume mining after sync was finished
+						miningRequested = true
+						log.Info("Mining aborted due to sync")
+					}
 				}
-			case downloader.DoneEvent, downloader.FailedEvent:
+			case downloader.FailedEvent:
 				canStart = true
-				if shouldStart {
+				if miningRequested {
+					miner.SetEtherbase(miner.coinbase)
+					miner.worker.start()
+				}
+			case downloader.DoneEvent:
+				canStart = true
+				downloaderCanStop = false
+				if miningRequested {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}
@@ -118,9 +128,9 @@ func (miner *Miner) update() {
 				miner.SetEtherbase(addr)
 				miner.worker.start()
 			}
-			shouldStart = true
+			miningRequested = true
 		case <-miner.stopCh:
-			shouldStart = false
+			miningRequested = false
 			miner.worker.stop()
 		case <-miner.exitCh:
 			miner.worker.close()

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -111,14 +111,14 @@ func (miner *Miner) update() {
 				}
 			case downloader.FailedEvent:
 				canStart = true
-				if miningRequested {
+				if miningRequested && !miner.Mining() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}
 			case downloader.DoneEvent:
 				canStart = true
 				downloaderCanStop = false
-				if miningRequested {
+				if miningRequested && !miner.Mining() {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()
 				}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -80,49 +80,58 @@ func New(eth Backend, config *Config, chainConfig ctypes.ChainConfigurator, mux 
 	return miner
 }
 
-// update keeps track of the downloader events. Please be aware that this is a one shot type of update loop.
-// It's entered once and as soon as `Done` or `Failed` has been broadcasted the events are unregistered and
-// the loop is exited. This to prevent a major security vuln where external parties can DOS you with blocks
-// and halt your mining operation for as long as the DOS continues.
+// update handles miner start/stop/exit events, as well as a temporary subscription to downloader events.
+// Downloader events are used to pause and restart mining pending a successful sync operation.
 func (miner *Miner) update() {
-	events := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
-	defer events.Unsubscribe()
+	downloaderEvents := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	defer func() {
+		if !downloaderEvents.Closed() {
+			downloaderEvents.Unsubscribe()
+		}
+	}()
 
-	downloaderCanStop := true
 	miningRequested := false
 	canStart := true
+
+	// handleDownloaderEvents handles the downloader events. Please be aware that this is a one-shot type of logic.
+	// As soon as `Done` has been broadcast subsequent downloader events are not handled, and the event subscription is closed.
+	//
+	// This prevents a major security vulnerability where external parties can DOS you with blocks
+	// and halt your mining operation for as long as the DOS continues.
+	handleDownloaderEvents := func(ev *event.TypeMuxEvent) {
+		switch ev.Data.(type) {
+		case downloader.StartEvent:
+			wasMining := miner.Mining()
+			miner.worker.stop()
+			canStart = false
+			if wasMining {
+				// Resume mining after sync was finished
+				miningRequested = true
+				log.Info("Mining aborted due to sync")
+			}
+		case downloader.FailedEvent:
+			canStart = true
+			if miningRequested {
+				miner.SetEtherbase(miner.coinbase)
+				miner.worker.start()
+			}
+		case downloader.DoneEvent:
+			canStart = true
+			if miningRequested {
+				miner.SetEtherbase(miner.coinbase)
+				miner.worker.start()
+			}
+			downloaderEvents.Unsubscribe()
+		}
+	}
+
 	for {
 		select {
-		case ev := <-events.Chan():
+		case ev := <-downloaderEvents.Chan():
 			if ev == nil {
 				return
 			}
-			switch ev.Data.(type) {
-			case downloader.StartEvent:
-				if downloaderCanStop {
-					wasMining := miner.Mining()
-					miner.worker.stop()
-					canStart = false
-					if wasMining {
-						// Resume mining after sync was finished
-						miningRequested = true
-						log.Info("Mining aborted due to sync")
-					}
-				}
-			case downloader.FailedEvent:
-				canStart = true
-				if miningRequested && !miner.Mining() {
-					miner.SetEtherbase(miner.coinbase)
-					miner.worker.start()
-				}
-			case downloader.DoneEvent:
-				canStart = true
-				downloaderCanStop = false
-				if miningRequested && !miner.Mining() {
-					miner.SetEtherbase(miner.coinbase)
-					miner.worker.start()
-				}
-			}
+			handleDownloaderEvents(ev)
 		case addr := <-miner.startCh:
 			if canStart {
 				miner.SetEtherbase(addr)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -127,14 +127,11 @@ func (miner *Miner) update() {
 
 	// Handle downloader events while subscription is open.
 	go func() {
-		for {
-			select {
-			case ev := <-downloaderEvents.Chan():
-				if ev == nil {
-					return
-				}
-				handleDownloaderEvents(ev)
+		for ev := range downloaderEvents.Chan() {
+			if ev == nil {
+				return
 			}
+			handleDownloaderEvents(ev)
 		}
 	}()
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -107,6 +107,7 @@ func (miner *Miner) update() {
 					log.Info("Mining aborted due to sync")
 				}
 			case downloader.DoneEvent, downloader.FailedEvent:
+				canStart = true
 				if shouldStart {
 					miner.SetEtherbase(miner.coinbase)
 					miner.worker.start()

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -125,13 +125,21 @@ func (miner *Miner) update() {
 		}
 	}
 
+	// Handle downloader events while subscription is open.
+	go func() {
+		for {
+			select {
+			case ev := <-downloaderEvents.Chan():
+				if ev == nil {
+					return
+				}
+				handleDownloaderEvents(ev)
+			}
+		}
+	}()
+
 	for {
 		select {
-		case ev := <-downloaderEvents.Chan():
-			if ev == nil {
-				return
-			}
-			handleDownloaderEvents(ev)
 		case addr := <-miner.startCh:
 			if canStart {
 				miner.SetEtherbase(addr)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -91,7 +91,7 @@ func (miner *Miner) update() {
 	}()
 
 	miningRequested := false
-	canStart := true
+	isDownloading := false
 
 	// handleDownloaderEvents handles the downloader events. Please be aware that this is a one-shot type of logic.
 	// As soon as `Done` has been broadcast subsequent downloader events are not handled, and the event subscription is closed.
@@ -103,20 +103,20 @@ func (miner *Miner) update() {
 		case downloader.StartEvent:
 			wasMining := miner.Mining()
 			miner.worker.stop()
-			canStart = false
+			isDownloading = true
 			if wasMining {
 				// Resume mining after sync was finished
 				miningRequested = true
 				log.Info("Mining aborted due to sync")
 			}
 		case downloader.FailedEvent:
-			canStart = true
+			isDownloading = false
 			if miningRequested {
 				miner.SetEtherbase(miner.coinbase)
 				miner.worker.start()
 			}
 		case downloader.DoneEvent:
-			canStart = true
+			isDownloading = false
 			if miningRequested {
 				miner.SetEtherbase(miner.coinbase)
 				miner.worker.start()
@@ -125,20 +125,37 @@ func (miner *Miner) update() {
 		}
 	}
 
-	// Handle downloader events while subscription is open.
-	go func() {
-		for ev := range downloaderEvents.Chan() {
+	// withDownloaderState loop handles channeled events while the miner cares about the downloader events.
+	// This loop will be broken once the downloader emits a DoneEvent, signaling a successful sync.
+	// The following unnamed loop should be equivalent to this loop, but without the downloader event handling.
+withDownloaderState:
+	for {
+		select {
+		case ev := <-downloaderEvents.Chan():
 			if ev == nil {
-				return
+				break withDownloaderState
 			}
 			handleDownloaderEvents(ev)
+		case addr := <-miner.startCh:
+			if !isDownloading {
+				miner.SetEtherbase(addr)
+				miner.worker.start()
+			}
+			miningRequested = true
+		case <-miner.stopCh:
+			miningRequested = false
+			miner.worker.stop()
+		case <-miner.exitCh:
+			miner.worker.close()
+			return
 		}
-	}()
+	}
 
+	// Same loop as above, minus downloader event handling.
 	for {
 		select {
 		case addr := <-miner.startCh:
-			if canStart {
+			if !isDownloading {
 				miner.SetEtherbase(addr)
 				miner.worker.start()
 			}

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -89,10 +89,10 @@ func TestMiner(t *testing.T) {
 	// Stop the downloader and wait for the update loop to run
 	mux.Post(downloader.DoneEvent{})
 	waitForMiningState(t, miner, true)
-	// Start the downloader and wait for the update loop to run
+	// Start the downloader, the mining state will not change because the update loop has exited
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
-	// Stop the downloader and wait for the update loop to run
+	waitForMiningState(t, miner, true)
+	// Stop the downloader, the mining state will not change
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -90,8 +90,13 @@ func TestMiner(t *testing.T) {
 	mux.Post(downloader.DoneEvent{})
 	waitForMiningState(t, miner, true)
 
+	// Subsequent downloader events should not cause the
+	// miner to start or stop. This prevents a security vulnerability
+	// that would allow entities to present fake high blocks that would
+	// stop mining operations by causing a downloader sync
+	// until it was discovered they were invalid, whereon mining would resume.
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
+	waitForMiningState(t, miner, true)
 
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -104,7 +104,7 @@ func TestMiner(t *testing.T) {
 
 // TestMinerDownloaderFirstFails tests that mining is only
 // permitted to run indefinitely once the downloader sees a DoneEvent (success).
-// With this, a FailEvent should not prohibit mining stopping on a subsequent
+// An initial FailedEvent should allow mining to stop on a subsequent
 // downloader StartEvent.
 func TestMinerDownloaderFirstFails(t *testing.T) {
 	miner, mux := createMiner(t)

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -89,10 +89,10 @@ func TestMiner(t *testing.T) {
 	// Stop the downloader and wait for the update loop to run
 	mux.Post(downloader.DoneEvent{})
 	waitForMiningState(t, miner, true)
-	// Start the downloader, the mining state will not change because the update loop has exited
+
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, true)
-	// Stop the downloader, the mining state will not change
+	waitForMiningState(t, miner, false)
+
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)
 }
@@ -158,10 +158,10 @@ func waitForMiningState(t *testing.T, m *Miner, mining bool) {
 
 	var state bool
 	for i := 0; i < 100; i++ {
+		time.Sleep(10 * time.Millisecond)
 		if state = m.Mining(); state == mining {
 			return
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("Mining() == %t, want %t", state, mining)
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -135,7 +135,29 @@ func TestMinerDownloaderFirstFails(t *testing.T) {
 
 	mux.Post(downloader.FailedEvent{})
 	waitForMiningState(t, miner, true)
+}
 
+func TestMinerStartStopAfterDownloaderEvents(t *testing.T) {
+	miner, mux := createMiner(t)
+
+	miner.Start(common.HexToAddress("0x12345"))
+	waitForMiningState(t, miner, true)
+	// Start the downloader
+	mux.Post(downloader.StartEvent{})
+	waitForMiningState(t, miner, false)
+
+	// Downloader finally succeeds.
+	mux.Post(downloader.DoneEvent{})
+	waitForMiningState(t, miner, true)
+
+	miner.Stop()
+	waitForMiningState(t, miner, false)
+
+	miner.Start(common.HexToAddress("0x678910"))
+	waitForMiningState(t, miner, true)
+
+	miner.Stop()
+	waitForMiningState(t, miner, false)
 }
 
 func TestStartWhileDownload(t *testing.T) {

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -97,27 +97,6 @@ func TestMiner(t *testing.T) {
 	waitForMiningState(t, miner, true)
 }
 
-// TestMiner_2 shows that TestMiner assertions 'waitForMiningState' are
-// imprecise measurements. The last two assertions use 'false' where the original
-// test uses 'true'. The test passes.
-func TestMiner_2(t *testing.T) {
-	miner, mux := createMiner(t)
-	miner.Start(common.HexToAddress("0x12345"))
-	waitForMiningState(t, miner, true)
-	// Start the downloader
-	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
-	// Stop the downloader and wait for the update loop to run
-	mux.Post(downloader.DoneEvent{})
-	waitForMiningState(t, miner, true)
-	// Start the downloader, the mining state will not change because the update loop has exited
-	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, miner, false)
-	// Stop the downloader, the mining state will not change
-	mux.Post(downloader.FailedEvent{})
-	waitForMiningState(t, miner, false)
-}
-
 func TestStartWhileDownload(t *testing.T) {
 	miner, mux := createMiner(t)
 	waitForMiningState(t, miner, false)


### PR DESCRIPTION
Following the logic of the comment at the method,
this fixes a regression introduced at 7cf56d6f064869cb62b1673f9ee437020c595391
, which would allow external parties to DoS with
blocks, preventing mining progress.

Rel #199 


Corresponding upstream PR at https://github.com/ethereum/go-ethereum/pull/21653