### PR TITLE
main: fix dumpconfig toml marshaling with nil value

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -195,6 +195,15 @@ func dumpConfig(ctx *cli.Context) error {
 		comment += "# Note: this config doesn't contain the genesis block.\n\n"
 	}
 
+	// HACK(meowsbits):
+	// The Ethash Config uses a nil-able field ECIP1099Block. The toml marshaler fails
+	// when trying to marshal the nil value.
+	// To fix this, if the value is nil, set it to a functionally equitable, but non-nil, value.
+	if cfg.Eth.Ethash.ECIP1099Block == nil {
+		max := uint64(math.MaxUint64)
+		cfg.Eth.Ethash.ECIP1099Block = &max
+	}
+
 	out, err := tomlSettings.Marshal(&cfg)
 	if err != nil {
 		return err

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -195,15 +195,6 @@ func dumpConfig(ctx *cli.Context) error {
 		comment += "# Note: this config doesn't contain the genesis block.\n\n"
 	}
 
-	// HACK(meowsbits):
-	// The Ethash Config uses a nil-able field ECIP1099Block. The toml marshaler fails
-	// when trying to marshal the nil value.
-	// To fix this, if the value is nil, set it to a functionally equitable, but non-nil, value.
-	if cfg.Eth.Ethash.ECIP1099Block == nil {
-		max := uint64(math.MaxUint64)
-		cfg.Eth.Ethash.ECIP1099Block = &max
-	}
-
 	out, err := tomlSettings.Marshal(&cfg)
 	if err != nil {
 		return err

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -429,7 +429,7 @@ type Config struct {
 
 	Log log.Logger `toml:"-"`
 	// ECIP-1099
-	ECIP1099Block *uint64
+	ECIP1099Block *uint64 `toml:"-"`
 }
 
 // Ethash is a consensus engine based on proof-of-work implementing the ethash


### PR DESCRIPTION
This fixes a TOML marshaling error resulting from
a nil value for the Ethash ECIP1099Block field.

Fixes #213 