### PR TITLE
Bit boundary fix for the DAG generation routine

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -320,16 +320,16 @@ func generateDataset(dest []uint32, epoch uint64, epochLength uint64, cache []ui
 			keccak512 := makeHasher(sha3.NewLegacyKeccak512())
 
 			// Calculate the data segment this thread should generate
-			batch := uint32((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
-			first := uint32(id) * batch
+			batch := uint64((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
+			first := uint64(id) * batch
 			limit := first + batch
-			if limit > uint32(size/hashBytes) {
-				limit = uint32(size / hashBytes)
+			if limit > uint64(size/hashBytes) {
+				limit = uint64(size / hashBytes)
 			}
 			// Calculate the dataset segment
 			percent := uint32(size / hashBytes / 100)
 			for index := first; index < limit; index++ {
-				item := generateDatasetItem(cache, index, keccak512)
+				item := generateDatasetItem(cache, uint32(index), keccak512)
 				if swapped {
 					swap(item)
 				}

--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -320,11 +320,11 @@ func generateDataset(dest []uint32, epoch uint64, epochLength uint64, cache []ui
 			keccak512 := makeHasher(sha3.NewLegacyKeccak512())
 
 			// Calculate the data segment this thread should generate
-			batch := uint64((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
+			batch := (size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads))
 			first := uint64(id) * batch
 			limit := first + batch
-			if limit > uint64(size/hashBytes) {
-				limit = uint64(size / hashBytes)
+			if limit > size/hashBytes {
+				limit = size / hashBytes
 			}
 			// Calculate the dataset segment
 			percent := uint32(size / hashBytes / 100)


### PR DESCRIPTION
If DAG size is exceeding the maximum 32 bit unsigned value, the DAG generation will produce incorrect results depending on the number of threads available on the host machine. Switch the generation to 64 bit variable to fix this.

Note that a hard fork may be required on the ETC network for the time being as we're already on the epoch 385 which generates a DAG file of 4.008 Gb, causing some nodes to reject valid blocks, depending on the conditions under which they have generated a new DAG file under.