### PR TITLE
main: fix usage for copydb command

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -178,7 +178,8 @@ The export-preimages command export hash preimages to an RLP encoded stream`,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
-The first argument must be the directory containing the blockchain to download from`,
+The first argument must be the chaindata directory containing the blockchain to download from.
+The second argument must be the ancient chain directory path.`,
 	}
 	removedbCommand = cli.Command{
 		Action:    utils.MigrateFlags(removeDB),


### PR DESCRIPTION
The help text noted the mandatory first arg,
but not the mandatory second arg, which is
the path to the ancient data dir.

Signed-off-by: meows <b5c6@protonmail.com>

---

Rel #222. 