### PR TITLE
Release/v1.11.18

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 11         // Minor version component of the current release
-	VersionPatch = 18         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 11       // Minor version component of the current release
+	VersionPatch = 18       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 11       // Minor version component of the current release
-	VersionPatch = 18       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 11         // Minor version component of the current release
+	VersionPatch = 19         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
Core-Geth v1.11.18 is a security release. It is built with Go v1.15.5, fixing CVE-2020-28362, which has a critical impact for Ethereum and Ethereum Classic. (See https://github.com/ethereum/go-ethereum/releases/tag/v1.9.24).

__We recommend everyone to upgrade to this release or rebuild with Go 1.15.5.__

If you are building geth from source, please ensure you are building with Go v1.15.5 or above. We recommend using the latest Geth version, but if you are not mining and cannot upgrade to core-geth v1.11.18, please rebuild your current version with Go v1.15.5.

Note that other changes from ethereum/go-ethereum's v1.9.24 release are NOT included, though a merge branch is in progress at https://github.com/etclabscore/core-geth/pull/230. 