### PR TITLE
ethash: use hexutil.Encode instead of deprecated common.ToHex

### DIFF
--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -35,7 +35,7 @@ import (
 	"unsafe"
 
 	mmap "github.com/edsrzf/mmap-go"
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -90,7 +90,7 @@ func uint32Array2Keccak256(data []uint32) string {
 	// hash with keccak256
 	digest := crypto.Keccak256(bytes)
 	// return hex string
-	return common.ToHex(digest)
+	return hexutil.Encode(digest)
 }
 
 // memoryMap tries to memory map a file of uint32s for read only access.


### PR DESCRIPTION
Apply the https://github.com/ethereum/go-ethereum/commit/3eebf340386dee2f6a008664bf8a1e82842a053e to Ethash changes with regards ECIP1099