### PR TITLE
Update bad cache & dataset hashes

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -68,7 +68,7 @@ func calcEpoch(block uint64, epochLength uint64) uint64 {
 
 // cacheSize returns the size of the ethash verification cache that belongs to a certain
 // block number.
-func cacheSize(block uint64, epoch uint64) uint64 {
+func cacheSize(epoch uint64) uint64 {
 	if epoch < maxEpoch {
 		return cacheSizes[int(epoch)]
 	}
@@ -88,7 +88,7 @@ func calcCacheSize(epoch uint64) uint64 {
 
 // datasetSize returns the size of the ethash mining dataset that belongs to a certain
 // block number.
-func datasetSize(block uint64, epoch uint64) uint64 {
+func datasetSize(epoch uint64) uint64 {
 	if epoch < maxEpoch {
 		return datasetSizes[int(epoch)]
 	}

--- a/consensus/ethash/algorithm_test.go
+++ b/consensus/ethash/algorithm_test.go
@@ -768,7 +768,7 @@ func TestConcurrentDiskCacheGeneration(t *testing.T) {
 // Benchmarks the cache generation performance.
 func BenchmarkCacheGeneration(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		cache := make([]uint32, cacheSize(1, 0)/4)
+		cache := make([]uint32, cacheSize(0)/4)
 		generateCache(cache, 0, epochLengthDefault, make([]byte, 32))
 	}
 }
@@ -787,14 +787,14 @@ func BenchmarkSmallDatasetGeneration(b *testing.B) {
 
 // Benchmarks the light verification performance.
 func BenchmarkHashimotoLight(b *testing.B) {
-	cache := make([]uint32, cacheSize(1, 0)/4)
+	cache := make([]uint32, cacheSize(0)/4)
 	generateCache(cache, 0, epochLengthDefault, make([]byte, 32))
 
 	hash := hexutil.MustDecode("0xc9149cc0386e689d789a1c2f3d5d169a61a6218ed30e74414dc736e442ef3d1f")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		hashimotoLight(datasetSize(1, 0), cache, hash, 0)
+		hashimotoLight(datasetSize(0), cache, hash, 0)
 	}
 }
 

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -504,7 +504,7 @@ func (ethash *Ethash) verifySeal(chain consensus.ChainHeaderReader, header *type
 		cache := ethash.cache(number)
 		epochLength := calcEpochLength(number, ethash.config.ECIP1099Block)
 		epoch := calcEpoch(number, epochLength)
-		size := datasetSize(number, epoch)
+		size := datasetSize(epoch)
 		if ethash.config.PowMode == ModeTest {
 			size = 32 * 1024
 		}

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -308,7 +308,7 @@ func isBadCache(epoch uint64, epochLength uint64, data []uint32) (bool, string) 
 // generate ensures that the cache content is generated before use.
 func (c *cache) generate(dir string, limit int, lock bool, test bool) {
 	c.once.Do(func() {
-		size := cacheSize(c.epoch*c.epochLength+1, c.epoch)
+		size := cacheSize(c.epoch)
 		seed := seedHash(c.epoch*c.epochLength + 1)
 		if test {
 			size = 1024
@@ -395,8 +395,8 @@ func (d *dataset) generate(dir string, limit int, lock bool, test bool) {
 		// Mark the dataset generated after we're done. This is needed for remote
 		defer atomic.StoreUint32(&d.done, 1)
 
-		csize := cacheSize(d.epoch*d.epochLength+1, d.epoch)
-		dsize := datasetSize(d.epoch*d.epochLength+1, d.epoch)
+		csize := cacheSize(d.epoch)
+		dsize := datasetSize(d.epoch)
 		seed := seedHash(d.epoch*d.epochLength + 1)
 		if test {
 			csize = 1024

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -286,6 +286,13 @@ func isBadCache(epoch uint64, epochLength uint64, data []uint32) (bool, string) 
 			// bad dataset generated using: geth makedag 11700001 [path] --epoch.length=30000
 			badDataset = "0xe9cc9df33ee6de075558fb07fd67d59068a9751c36c6e9ae38163f6da90a2240"
 		}
+		if epoch == 196 { // classic mainnet
+			hash = uint32Array2Keccak256(data)
+			// bad cache generated using: geth makecache 11760001 [path] --epoch.length=30000
+			badCache = "0x4a37ee8c8cb4f75c05e23369cadeec7a6ed7386226a629794a733e0249d92d5f"
+			// bad dataset generated using: geth makedag 11760001 [path] --epoch.length=30000
+			badDataset = "0xf281b059ce535a7c146c00ada26114406bc08a9657bf9147542f92f9f9f08bf2"
+		}
 		// check if cache is bad
 		if hash != "" && (hash == badCache || hash == badDataset) {
 			// cache/dataset is bad.

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -284,7 +284,7 @@ func isBadCache(epoch uint64, epochLength uint64, data []uint32) (bool, string) 
 			// bad cache generated using: geth makecache 11700001 [path] --epoch.length=30000
 			badCache = "0x5794130ea9e433185214fb4032edbd3473499267e197d9003a6a1a5bd300b3e5"
 			// bad dataset generated using: geth makedag 11700001 [path] --epoch.length=30000
-			badDataset = "0x9d90f9777150c0a9ed94ae17839e246d3fb0042e8d97903e3a7bf87357cef656"
+			badDataset = "0xe9cc9df33ee6de075558fb07fd67d59068a9751c36c6e9ae38163f6da90a2240"
 		}
 		// check if cache is bad
 		if hash != "" && (hash == badCache || hash == badDataset) {


### PR DESCRIPTION
The original hashes produced for the classic mainnet transition were produced before the uint32 overflow fix. Although at the time of generation the bug was unknown, these future datasets are large enough to trigger the overflow so were impacted.

* This PR updates ecip-1099 epoch 195 bad dataset hash.
* Adds bad cache and dataset hashes for ecip-1099 epoch 196.
* Refactors cacheSize & datasetSize, removing the now unused block argument.