### PR TITLE
main: fix spurious error logs for empty bootnodes flag val

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -272,7 +272,7 @@ func main() {
 	log.Info("configured chain/net config", "network id", *netFlag, "bootnodes", *bootFlag, "chain config", fmt.Sprintf("%v", genesis.Config))
 
 	// Convert the bootnodes to internal enode representations
-	for _, boot := range strings.Split(*bootFlag, ",") {
+	for _, boot := range utils.SplitAndTrim(*bootFlag) {
 		if url, err := discv5.ParseNode(boot); err == nil {
 			enodes = append(enodes, url)
 		} else {


### PR DESCRIPTION
Program logged ERROR level logs about
failing to parse bootnodes when in fact none were
passed.

This fix checks for empty values before
attempting to parse bootnode values.

Date: 2020-12-07 07:14:06-06:00
Signed-off-by: meows <b5c6@protonmail.com>