### PR TITLE
rawdb: ignore ancient writes below frozen marker

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -191,10 +191,19 @@ func (f *freezer) AncientSize(kind string) (uint64, error) {
 // injection will be rejected. But if two injections with same number happen at
 // the same time, we can get into the trouble.
 func (f *freezer) AppendAncient(number uint64, hash, header, body, receipts, td []byte) (err error) {
+
 	// Ensure the binary blobs we are appending is continuous with freezer.
-	if atomic.LoadUint64(&f.frozen) != number {
-		return errOutOrderInsertion
+	if frozen := atomic.LoadUint64(&f.frozen); frozen < number {
+		// Have to return an error here because other would gape.
+		return fmt.Errorf("%w: ancients=%d", errOutOrderInsertion, frozen)
+	} else if frozen > number {
+		// If we already have this block frozen, ignore.
+		// Truncate is used exclusively and explicitly to remove reverted canonical data,
+		// so if we are trying to store an ancient block that we already have it just means
+		// that we're doing redundant, non-mutating work.
+		return nil
 	}
+
 	// Rollback all inserted data if any insertion below failed to ensure
 	// the tables won't out of sync.
 	defer func() {


### PR DESCRIPTION
This issue has become very annoying for me.
https://github.com/etclabscore/core-geth/issues/245

This resolves it, although obviously not in an ideal way.
There has got to be an off-by-one somewhere that, when
the chain get 'Rewind to 1', or somewhere in download->import,
block num 1 is attempted for ancient storage duplicitously.

The code comments hopefully explain why its OK
to ignore AppendAncient when the block is below
the ancient water level.

Date: 2020-12-11 10:45:45-06:00
Signed-off-by: meows <b5c6@protonmail.com>