### PR TITLE
Set default fallback for copydb 2nd ancient path arg

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -179,7 +179,7 @@ The export-preimages command export hash preimages to an RLP encoded stream`,
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
 The first argument must be the chaindata directory containing the blockchain to download from.
-The second argument must be the ancient chain directory path.`,
+The second argument can be the ancient chain directory path (default = inside chaindata).`,
 	}
 	removedbCommand = cli.Command{
 		Action:    utils.MigrateFlags(removeDB),
@@ -463,8 +463,11 @@ func copyDb(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("Source chaindata directory path argument missing")
 	}
-	if len(ctx.Args()) < 2 {
-		utils.Fatalf("Source ancient chain directory path argument missing")
+	root := ctx.Args().First()
+	freezer := filepath.Join(root, "ancient")
+	// Ancient freeer path can be set as a second argument
+	if len(ctx.Args()) == 2 {
+		freezer = ctx.Args().Get(1)
 	}
 	// Initialize a new chain for the running node to sync into
 	stack, _ := makeConfigNode(ctx)
@@ -480,7 +483,7 @@ func copyDb(ctx *cli.Context) error {
 	dl := downloader.New(0, chainDb, syncBloom, new(event.TypeMux), chain, nil, nil)
 
 	// Create a source peer to satisfy downloader requests from
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(ctx.Args().First(), ctx.GlobalInt(utils.CacheFlag.Name)/2, 256, ctx.Args().Get(1), "")
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(root, ctx.GlobalInt(utils.CacheFlag.Name)/2, 256, freezer, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The second arg, which is the path to the ancient data dir becomes optional, and fallbacks/defaults to be inside the chaindata passed as the first arg.

The final default path for the ancient datadir becomes “<first_arg>/ancient”.

This PR is based on https://github.com/etclabscore/core-geth/pull/227#issuecomment-739919123