### PR TITLE
Faucet: Add log when importing faucet signer account

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -293,7 +293,7 @@ func main() {
 	acc, err := ks.Import(blob, pass, pass)
 	if err != nil && err != keystore.ErrAccountAlreadyExists {
 		log.Crit("Failed to import faucet signer account", "err", err)
-	} else if err != keystore.ErrAccountAlreadyExists {
+	} else if err == nil {
 		log.Info("Imported faucet signer account", "address", acc.Address)
 	}
 	if err := ks.Unlock(acc, pass); err != nil {

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -293,6 +293,8 @@ func main() {
 	acc, err := ks.Import(blob, pass, pass)
 	if err != nil && err != keystore.ErrAccountAlreadyExists {
 		log.Crit("Failed to import faucet signer account", "err", err)
+	} else if err != keystore.ErrAccountAlreadyExists {
+		log.Info("Imported faucet signer account", "address", acc.Address)
 	}
 	if err := ks.Unlock(acc, pass); err != nil {
 		log.Crit("Failed to unlock faucet signer account", "err", err)


### PR DESCRIPTION
This PR adds just a log when the signer account is being imported, as some previous log messages (attached image) might be misleading, and the user might feel that account import failed.

![image](https://user-images.githubusercontent.com/802700/102818818-0ecac280-43db-11eb-9e2f-356b6714e4b0.png)
