### PR TITLE
cmd/faucet/main: fix eth backend API initialization

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -495,27 +495,29 @@ func (f *faucet) startStack(genesis *genesisT.Genesis, port int, enodes []*discv
 	log.Info("Config discovery", "urls", cfg.DiscoveryURLs)
 
 	// Establish the backend and enable stats reporting if configured to do so.
-	if *statsFlag != "" {
-		switch *syncmodeFlag {
-		case "light":
-			lesBackend, err := les.New(stack, &cfg)
-			if err != nil {
-				return fmt.Errorf("Failed to register the Ethereum service: %w", err)
-			}
+	switch *syncmodeFlag {
+	case "light":
+		lesBackend, err := les.New(stack, &cfg)
+		if err != nil {
+			return fmt.Errorf("Failed to register the Ethereum service: %w", err)
+		}
+		if *statsFlag != "" {
 			if err := ethstats.New(stack, lesBackend.ApiBackend, lesBackend.Engine(), *statsFlag); err != nil {
 				return err
 			}
-		case "fast", "full":
-			ethBackend, err := eth.New(stack, &cfg)
-			if err != nil {
-				return fmt.Errorf("Failed to register the Ethereum service: %w", err)
-			}
+		}
+	case "fast", "full":
+		ethBackend, err := eth.New(stack, &cfg)
+		if err != nil {
+			return fmt.Errorf("Failed to register the Ethereum service: %w", err)
+		}
+		if *statsFlag != "" {
 			if err := ethstats.New(stack, ethBackend.APIBackend, ethBackend.Engine(), *statsFlag); err != nil {
 				return err
 			}
-		default:
-			panic("impossible to reach, this should be handled in the auditFlagUse function")
 		}
+	default:
+		panic("impossible to reach, this should be handled in the auditFlagUse function")
 	}
 
 	// Boot up the client and ensure it connects to bootnodes


### PR DESCRIPTION
Date: 2021-01-08 07:16:52-06:00
Signed-off-by: meows <b5c6@protonmail.com>


This shortsighted attempt to make the code a little cleaner accidentally skips backend initialization, causing the API to be unavailable:

```
INFO [01-08|07:08:53.615] UDP listener up                          net=enode://c962ee36f480cd989e523bf6171a9de640e6bc1ec2fb89b2d0e58c8783d54429b8e0ed8e70cf0afd35c610778228dbd7d124c538783f63675e962df86adda339@[::]:33333
INFO [01-08|07:08:53.615] Started P2P networking                   self=enode://c962ee36f480cd989e523bf6171a9de640e6bc1ec2fb89b2d0e58c8783d54429b8e0ed8e70cf0afd35c610778228dbd7d124c538783f63675e962df86adda339@127.0.0.1:33333
WARN [01-08|07:08:53.616] Served eth_subscribe                     reqid=1 t="14.036µs" err="no \"newHeads\" subscription in eth namespace"
CRIT [01-08|07:08:53.616] Failed to subscribe to head events       err="no \"newHeads\" subscription in eth namespace"
```
