### PR TITLE
Feat/migrate faucet node datadir: MultiFaucet -> CoreFaucet

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -434,16 +434,58 @@ type faucet struct {
 	lock sync.RWMutex // Lock protecting the faucet's internals
 }
 
+const (
+	multiFaucetNodeName = "MultiFaucet"
+	coreFaucetNodeName  = "CoreFaucet"
+)
+
+// migrateFaucetDirectory moves an existing "MultiFaucet" directory to the new "CoreFaucet".
+// It only returns an error if the migration is attempted and fails.
+// If no 'old' directory is found to migrate (ie DNE), it returns nil (no error).
+func migrateFaucetDirectory(faucetDataDir string) error {
+	oldFaucetNodePath := filepath.Join(faucetDataDir, multiFaucetNodeName)
+	targetFaucetNodePath := filepath.Join(faucetDataDir, coreFaucetNodeName)
+
+	log.Info("Checking datadir migration", "datadir", faucetDataDir)
+
+	d, err := os.Stat(oldFaucetNodePath)
+	if err != nil && os.IsNotExist(err) {
+		// This is an expected positive error.
+		return nil
+	}
+	if err == nil && d.IsDir() {
+
+		// Path exists and is a directory.
+		log.Warn("Found existing 'MultiFaucet' directory, migrating", "old", oldFaucetNodePath, "new", targetFaucetNodePath)
+		if err := os.Rename(oldFaucetNodePath, targetFaucetNodePath); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err == nil && !d.IsDir() {
+		return errors.New("expected a directory at faucet node datadir path, found non-directory")
+	}
+	// Return any error which is not expected, eg. bad permissions.
+	return err
+}
+
 // startStack starts the node stack, ensures peering, and assigns the respective ethclient to the faucet.
 func (f *faucet) startStack(genesis *genesisT.Genesis, port int, enodes []*discv5.Node, network uint64) error {
 
 	genesisHash := core.GenesisToBlock(genesis, nil).Hash()
 
+	faucetDataDir := faucetDirFromChainIndicators(genesis.Config.GetChainID().Uint64(), genesisHash)
+
+	// Handle renaming of existing directory from old name to new name.
+	if err := migrateFaucetDirectory(faucetDataDir); err != nil {
+		log.Crit("Migration handling of faucet datadir failed", "error", err)
+	}
+
 	// Assemble the raw devp2p protocol stack
 	stack, err := node.New(&node.Config{
-		Name:    "MultiFaucet",
+		Name:    coreFaucetNodeName,
 		Version: params.VersionWithCommit(gitCommit, gitDate),
-		DataDir: faucetDirFromChainIndicators(genesis.Config.GetChainID().Uint64(), genesisHash),
+		DataDir: faucetDataDir,
 		P2P: p2p.Config{
 			NAT: nat.Any(),
 			// NoDiscovery is DISABLED to allow the node the find peers without relying on manually configured bootnodes.

--- a/cmd/faucet/faucet_test.go
+++ b/cmd/faucet/faucet_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMigrateFaucetDirectory(t *testing.T) {
+	hardToCollideName := fmt.Sprintf("faucet-migration-test-datadir-%d", time.Now().UnixNano())
+	tempDir := filepath.Join(os.TempDir(), hardToCollideName)
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	faucetDataDir := filepath.Join(tempDir, "mychain")
+	oldFaucetNodeDataDir := filepath.Join(faucetDataDir, multiFaucetNodeName)
+
+	if err := os.MkdirAll(oldFaucetNodeDataDir, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	filepath.Walk(faucetDataDir, func(path string, info os.FileInfo, err error) error {
+		t.Logf("%s", path)
+		return nil
+	})
+
+	if err := migrateFaucetDirectory(faucetDataDir); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := filepath.Join(faucetDataDir, coreFaucetNodeName)
+	d, err := os.Stat(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.IsDir() {
+		t.Fatal("non-directory")
+	}
+	filepath.Walk(faucetDataDir, func(path string, info os.FileInfo, err error) error {
+		t.Logf("%s", path)
+		return nil
+	})
+}


### PR DESCRIPTION
Fixes #241.

Example: this version of `faucet` command has been run on `kotti`, but not yet on `mordor`, see below:

```
> tree -L 3 ~/.faucet.new/
/home/ia/.faucet.new/
├── kotti
│   ├── CoreFaucet
│   │   ├── chaindata
│   │   ├── lespay
│   │   ├── lightchaindata
│   │   ├── LOCK
│   │   ├── nodekey
│   │   ├── nodes
│   │   └── transactions.rlp
│   ├── keys
│   │   ├── UTC--2020-12-16T13-47-10.850820886Z--009bd67e2d46db4e2c948d89dfdc511723495e55
│   │   └── UTC--2021-01-08T13-29-39.927739695Z--75a80d93a947bc9e4ed0c8ddc898762951931e13
│   └── keystore
└── mordor
    ├── keys
    │   └── UTC--2020-12-08T12-46-53.960517227Z--870f00cee57a7482378f62e7b007f5b3a4fb94c6
    ├── keystore
    └── MultiFaucet
        ├── lespay
        ├── lightchaindata
        ├── LOCK
        ├── nodekey
        └── nodes
```