### PR TITLE
cmd/utils/flags: better help text for `—ethash.dagdir`

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -315,7 +315,7 @@ var (
 	}
 	EthashDatasetDirFlag = DirectoryFlag{
 		Name:  "ethash.dagdir",
-		Usage: "Directory to store the ethash mining DAGs",
+		Usage: "Directory to store the [ethash|etchash] mining DAGs based on supported network",
 		Value: DirectoryString(eth.DefaultConfig.Ethash.DatasetDir),
 	}
 	EthashDatasetsInMemoryFlag = cli.IntFlag{


### PR DESCRIPTION
Closes #247.

Here is the final help text:
```
> geth --help | grep dagdir
  --ethash.dagdir value               Directory to store the [ethash|etchash] mining DAGs based on supported network (default: "/Users/ziogaschr/Library/Ethash")
  ```

It wasn't easy to set the suggested one * as the default is being set from the `urfave/cli` package.

*: `Directory to store the [ethash|etchash] mining DAGs (default: "/Users/ziogaschr/Library/[Ethash|Etchash]") based on supported network.`