### PR TITLE
cmd/faucet: fatal error on attached node client connection drop

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -1042,6 +1042,10 @@ func (f *faucet) loop() {
 				}
 			}
 			f.lock.RUnlock()
+		case err := <-sub.Err():
+			if *attachFlag != "" {
+				log.Crit("Connection with the attached client has been lost", "err", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #280

When faucet attaches to an existing synced node and RPC connection throws an error it's [preferably to throw a Fatal error](https://github.com/etclabscore/core-geth/issues/280#issuecomment-757892682) and exit.