### PR TITLE
eth/filters,ethclient,node: install newSideHeads subscription

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1694,7 +1694,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		}
 		// In theory we should fire a ChainHeadEvent when we inject
 		// a canonical block, but sometimes we can insert a batch of
-		// canonicial blocks. Avoid firing too much ChainHeadEvents,
+		// canonical blocks. Avoid firing too much ChainHeadEvents,
 		// we will fire an accumulated ChainHeadEvent and disable fire
 		// event here.
 		if emitHeadEvent {

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -236,7 +236,6 @@ func (api *PublicFilterAPI) NewSideBlockFilter() rpc.ID {
 	return headerSub.ID
 }
 
-
 // NewHeads send a notification each time a new (header) block is appended to the chain.
 func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -203,6 +203,40 @@ func (api *PublicFilterAPI) NewBlockFilter() rpc.ID {
 	return headerSub.ID
 }
 
+// NewSideBlockFilter creates a filter that fetches blocks that are imported into the chain with a non-canonical status.
+// It is part of the filter package since polling goes with eth_getFilterChanges.
+func (api *PublicFilterAPI) NewSideBlockFilter() rpc.ID {
+	var (
+		headers   = make(chan *types.Header)
+		headerSub = api.events.SubscribeNewSideHeads(headers)
+	)
+
+	api.filtersMu.Lock()
+	api.filters[headerSub.ID] = &filter{typ: SideBlocksSubscription, deadline: time.NewTimer(deadline), hashes: make([]common.Hash, 0), s: headerSub}
+	api.filtersMu.Unlock()
+
+	go func() {
+		for {
+			select {
+			case h := <-headers:
+				api.filtersMu.Lock()
+				if f, found := api.filters[headerSub.ID]; found {
+					f.hashes = append(f.hashes, h.Hash())
+				}
+				api.filtersMu.Unlock()
+			case <-headerSub.Err():
+				api.filtersMu.Lock()
+				delete(api.filters, headerSub.ID)
+				api.filtersMu.Unlock()
+				return
+			}
+		}
+	}()
+
+	return headerSub.ID
+}
+
+
 // NewHeads send a notification each time a new (header) block is appended to the chain.
 func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
@@ -233,7 +267,37 @@ func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, er
 	return rpcSub, nil
 }
 
-// Logs creates a subscription that fires for all new log that match the given filter criteria.
+// NewHeads send a notification each time a new (header) block is appended to the chain.
+func (api *PublicFilterAPI) NewSideHeads(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		headers := make(chan *types.Header)
+		headersSub := api.events.SubscribeNewSideHeads(headers)
+
+		for {
+			select {
+			case h := <-headers:
+				notifier.Notify(rpcSub.ID, h)
+			case <-rpcSub.Err():
+				headersSub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				headersSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}
+
+// Logs creates a subscription that fires for all new logs that match the given filter criteria.
 func (api *PublicFilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
@@ -424,7 +488,7 @@ func (api *PublicFilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
 		f.deadline.Reset(deadline)
 
 		switch f.typ {
-		case PendingTransactionsSubscription, BlocksSubscription:
+		case PendingTransactionsSubscription, BlocksSubscription, SideBlocksSubscription:
 			hashes := f.hashes
 			f.hashes = nil
 			return returnHashes(hashes), nil

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -266,7 +266,7 @@ func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, er
 	return rpcSub, nil
 }
 
-// NewHeads send a notification each time a new (header) block is appended to the chain.
+// NewSideHeads send a notification each time a new non-canonical (header) block is written to the database.
 func (api *PublicFilterAPI) NewSideHeads(ctx context.Context) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -39,6 +39,7 @@ type Backend interface {
 
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
+	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -335,6 +335,12 @@ func (ec *Client) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header)
 	return ec.c.EthSubscribe(ctx, ch, "newHeads")
 }
 
+// SubscribeNewSideHead subscribes to notifications about the current blockchain head
+// on the given channel.
+func (ec *Client) SubscribeNewSideHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	return ec.c.EthSubscribe(ctx, ch, "newSideHeads")
+}
+
 // State Access
 
 // NetworkID returns the network ID (also known as the chain ID) for this chain.

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -725,6 +725,7 @@ var allRPCMethods = []string{
 	"eth_hashrate",
 	"eth_mining",
 	"eth_newBlockFilter",
+	"eth_newSideBlockFilter",
 	"eth_newFilter",
 	"eth_newPendingTransactionFilter",
 	"eth_pendingTransactions",

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -415,6 +416,149 @@ func TestRPCDiscover(t *testing.T) {
 
 	if len(over) > 0 || len(under) > 0 {
 		t.Fatalf("over: %v, under: %v", over, under)
+	}
+}
+
+func subscriptionTestSetup(t *testing.T) (genesisBlock *genesisT.Genesis, backend *node.Node) {
+	// Generate test chain.
+	// Code largely taken from generateTestChain()
+	chainConfig := params.TestChainConfig
+	genesis := &genesisT.Genesis{
+		Config:    chainConfig,
+		Alloc:     genesisT.GenesisAlloc{testAddr: {Balance: testBalance}},
+		ExtraData: []byte("test genesis"),
+		Timestamp: 9000,
+	}
+
+	// Create node
+	// Code largely taken from newTestBackend(t)
+	backend, err := node.New(&node.Config{})
+	if err != nil {
+		t.Fatalf("can't create new node: %v", err)
+	}
+
+	// Create Ethereum Service
+	config := &eth.Config{Genesis: genesis}
+	config.Ethash.PowMode = ethash.ModeFake
+
+	return genesis, backend
+}
+
+func TestEthSubscribeNewSideHeads(t *testing.T) {
+
+	genesis, backend := subscriptionTestSetup(t)
+
+	db := rawdb.NewMemoryDatabase()
+	chainConfig := genesis.Config
+
+	gblock := core.GenesisToBlock(genesis, db)
+	engine := ethash.NewFaker()
+	originalBlocks, _ := core.GenerateChain(chainConfig, gblock, engine, db, 10, func(i int, gen *core.BlockGen) {
+		gen.OffsetTime(5)
+		gen.SetExtra([]byte("test"))
+	})
+	originalBlocks = append([]*types.Block{gblock}, originalBlocks...)
+
+	// Create Ethereum Service
+	config := &eth.Config{Genesis: genesis}
+	config.Ethash.PowMode = ethash.ModeFake
+	ethservice, err := eth.New(backend, config)
+	if err != nil {
+		t.Fatalf("can't create new ethereum service: %v", err)
+	}
+
+	// Import the test chain.
+	if err := backend.Start(); err != nil {
+		t.Fatalf("can't start test node: %v", err)
+	}
+	if _, err := ethservice.BlockChain().InsertChain(originalBlocks[1:]); err != nil {
+		t.Fatalf("can't import test blocks: %v", err)
+	}
+
+	// Create the client and newSideHeads subscription.
+	client, err := backend.Attach()
+	defer backend.Close()
+	defer client.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ec := NewClient(client)
+	defer ec.Close()
+
+	sideHeadCh := make(chan *types.Header)
+	sub, err := ec.SubscribeNewSideHead(context.Background(), sideHeadCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Unsubscribe()
+
+	// Create and import the second-seen chain.
+	replacementBlocks, _ := core.GenerateChain(chainConfig, originalBlocks[len(originalBlocks)-5], ethservice.Engine(), db, 5, func(i int, gen *core.BlockGen) {
+		gen.OffsetTime(-9) // difficulty++
+	})
+	if _, err := ethservice.BlockChain().InsertChain(replacementBlocks); err != nil {
+		t.Fatalf("can't import test blocks: %v", err)
+	}
+
+	headersOf := func(bs []*types.Block) (headers []*types.Header) {
+		for _, b := range bs {
+			headers = append(headers, b.Header())
+		}
+		return
+	}
+
+	expectations := []*types.Header{}
+
+	// Why do we expect the replacement (second-seen) blocks reported as side events?
+	// Because they'll be inserted in ascending order, and until their segment exceeds the total difficulty
+	// of the incumbent chain, they won't achieve canonical status, despite having greater difficulty per block
+	// (see the time offset in the block generator function above).
+	expectations = append(expectations, headersOf(replacementBlocks[:3])...)
+
+	// Once the replacement blocks exceed the total difficulty of the original chain, the
+	// blocks they replace will be reported as side chain events.
+	expectations = append(expectations, headersOf(originalBlocks[7:])...)
+
+	// This is illustrated in the logs called below.
+	for i, b := range originalBlocks {
+		t.Log("incumbent", i, b.NumberU64(), b.Hash().Hex()[:8])
+	}
+	for i, b := range replacementBlocks {
+		t.Log("replacement", i, b.NumberU64(), b.Hash().Hex()[:8])
+	}
+
+	const timeoutDura = 5 * time.Second
+	timeout := time.NewTimer(timeoutDura)
+
+	got := []*types.Header{}
+waiting:
+	for {
+		select {
+		case head := <-sideHeadCh:
+			t.Log("<-newSideHeads", head.Number.Uint64(), head.Hash().Hex()[:8])
+			got = append(got, head)
+			if len(got) == len(expectations) {
+				timeout.Stop()
+				break waiting
+			}
+			timeout.Reset(timeoutDura)
+		case err := <-sub.Err():
+			t.Fatal(err)
+		case <-timeout.C:
+			t.Fatal("timed out")
+		}
+	}
+	for i, b := range expectations {
+		if got[i] == nil {
+			t.Error("missing expected header (test will improvise a fake value)")
+			// Set a nonzero value so I don't have to refactor this...
+			got[i] = &types.Header{Number: big.NewInt(math.MaxInt64)}
+		}
+		if got[i].Number.Uint64() != b.Number.Uint64() {
+			t.Errorf("number: want: %d, got: %d", b.Number.Uint64(), got[i].Number.Uint64())
+		} else if got[i].Hash() != b.Hash() {
+			t.Errorf("hash: want: %s, got: %s", b.Hash().Hex()[:8], got[i].Hash().Hex()[:8])
+		}
 	}
 }
 

--- a/node/openrpc.go
+++ b/node/openrpc.go
@@ -312,6 +312,7 @@ var blockNumberOrHashD = fmt.Sprintf(`{
 var rpcSubscriptionParamsNameD = `{
 		"oneOf": [
 			{"type": "string", "enum": ["newHeads"], "description": "Fires a notification each time a new header is appended to the chain, including chain reorganizations."},
+			{"type": "string", "enum": ["newSideHeads"], "description": "Fires a notification each time a new header is appended to the non-canonical (side) chain, including chain reorganizations."},
 			{"type": "string", "enum": ["logs"], "description": "Returns logs that are included in new imported blocks and match the given filter criteria."},
 			{"type": "string", "enum": ["newPendingTransactions"], "description": "Returns the hash for all transactions that are added to the pending state and are signed with a key that is available in the node."},
 			{"type": "string", "enum": ["syncing"], "description": "Indicates when the node starts or stops synchronizing. The result can either be a boolean indicating that the synchronization has started (true), finished (false) or an object with various progress indicators."}


### PR DESCRIPTION
The newSideHeads subscription work very similarly to
the newHeads subscription; instead, non-canonical blocks are channeled.

Resolves #287 