### PR TITLE
build,Makefile: add 'make mkdocs-serve'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 .PHONY: geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 .PHONY: geth-darwin geth-darwin-386 geth-darwin-amd64
 .PHONY: geth-windows geth-windows-386 geth-windows-amd64
+.PHONY: mkdocs-serve
 
 GOBIN = ./build/bin
 GO ?= latest
@@ -126,6 +127,9 @@ lint: ## Run linters.
 clean: clean-evmc
 	env GO111MODULE=on go clean -cache
 	rm -fr build/_workspace/pkg/ $(GOBIN)/*
+
+mkdocs-serve: ## Serve generated documentation (during development)
+	@build/mkdocs-serve.sh
 
 # The devtools target installs tools required for 'go generate'.
 # You need to put $GOBIN (or $GOPATH/bin) in your PATH to use 'go generate'.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Ellaism users are asked to switch to
 
 <a name="configuration-capable">2</a>: Network not supported by default, but network configuration is possible. Make a PR!
 
+## Documentation
+
+- CoreGeth documentation is available [here](https://etclabscore.github.io/core-geth). 
+- Further go-ethereum documentation about can be found [here](https://geth.ethereum.org/docs/). 
+- Developers interested in writing documentation, please find documentation about documentation [here](./docs/developers/documentation.md). 
+
 ## Install
 
 ### Pre-built executable

--- a/build/mkdocs-serve.sh
+++ b/build/mkdocs-serve.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# This script installs requirements for and starts the live-reloading development server for MkDocs.
+# MkDocs generates a static site from the markdown files in docs/.
+
+py_command=python
+pip_command=pip
+
+setup_py_command() {
+	if [ -z $(which ${py_command}) ]; then
+		py_command=python3
+		pip_command=pip3
+		return
+	fi
+	py_command_major_version=$(${py_command} 2>&1 --version | cut -d' ' -f2 | head -c1)
+	if [ $py_command_major_version != 3 ]; then
+		py_command=python3
+		pip_command=pip3
+	fi
+}
+setup_py_command
+
+set -ex
+${py_command} --version
+${pip_command} --version
+set +x
+
+${pip_command} install -r requirements-mkdocs.txt
+
+mkdocs serve

--- a/build/mkdocs-serve.sh
+++ b/build/mkdocs-serve.sh
@@ -4,18 +4,16 @@
 # MkDocs generates a static site from the markdown files in docs/.
 
 py_command=python
-pip_command=pip
+pip_command="${py_command} -m pip"
 
 setup_py_command() {
 	if [ -z $(which ${py_command}) ]; then
 		py_command=python3
-		pip_command=pip3
 		return
 	fi
 	py_command_major_version=$(${py_command} 2>&1 --version | cut -d' ' -f2 | head -c1)
 	if [ $py_command_major_version != 3 ]; then
 		py_command=python3
-		pip_command=pip3
 	fi
 }
 setup_py_command

--- a/build/mkdocs-serve.sh
+++ b/build/mkdocs-serve.sh
@@ -4,7 +4,6 @@
 # MkDocs generates a static site from the markdown files in docs/.
 
 py_command=python
-pip_command="${py_command} -m pip"
 
 setup_py_command() {
 	if [ -z $(which ${py_command}) ]; then
@@ -17,6 +16,7 @@ setup_py_command() {
 	fi
 }
 setup_py_command
+pip_command="${py_command} -m pip"
 
 set -ex
 ${py_command} --version

--- a/docs/developers/documentation.md
+++ b/docs/developers/documentation.md
@@ -1,0 +1,20 @@
+# Documentation
+
+Project documentation lives in `/docs` and is written in [Markdown](https://daringfireball.net/projects/markdown/syntax).  
+
+For web-based access, these files are passed through a static site generator [MkDocs](https://www.mkdocs.org/),
+specifically [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) and served via Github Pages.
+
+## Development
+
+You can run a live-reloading web server in imitation of the production generator. To do so:
+
+- Ensure that your python environment is using python3 and its package manager pip3. 
+  You can then install the required `mkdocs` executable and its dependencies using:
+  ```
+  python -m pip install -r requirements-mkdocs.txt
+  ```
+- Run `mdkocs serve` from the project root. A convenience Make command is likewise provided as `make mkdocs-serve`.
+- Open `http://localhost:8000` in a web browser.
+- Write some docs!
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - JSON-RPC: apis/jsonrpc-apis.md
     - OpenRPC: apis/openrpc.md
   - Developers:
+    - Documentation: developers/documentation.md
     - Versioning: developers/versioning.md
     - New release: developers/create-new-release.md
   - Tutorials:


### PR DESCRIPTION
This adds a script and associated Makefile command
to handle installing requirements and starting the
development server for mkdocs.

Signed-off-by: meows <b5c6@protonmail.com>