### PR TITLE
main,utils,eth: add CLI configuration overrides for ECBP1100 disablement limits

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -170,6 +170,16 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
 		}
 	}
+	if ctx.GlobalIsSet(utils.ECBP1100MinPeersFlag.Name) {
+		if n := ctx.GlobalInt(utils.ECBP1100MinPeersFlag.Name); n != -1 {
+			cfg.Eth.ECBP1100MinPeers = &n
+		}
+	}
+	if ctx.GlobalIsSet(utils.ECBP1100StaleHeadFlag.Name) {
+		if d := ctx.GlobalDuration(utils.ECBP1100StaleHeadFlag.Name); d.Seconds() != 0 {
+			cfg.Eth.ECBP1100StaleHead = &d
+		}
+	}
 
 	backend := utils.RegisterEthService(stack, &cfg.Eth)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -169,6 +169,8 @@ var (
 		utils.EWASMInterpreterFlag,
 		utils.EVMInterpreterFlag,
 		utils.ECBP1100Flag,
+		utils.ECBP1100MinPeersFlag,
+		utils.ECBP1100StaleHeadFlag,
 		configFileFlag,
 	}
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -61,6 +61,8 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,
 			utils.ECBP1100Flag,
+			utils.ECBP1100MinPeersFlag,
+			utils.ECBP1100StaleHeadFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -779,6 +779,16 @@ var (
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,
 	}
+	ECBP1100MinPeersFlag = cli.IntFlag{
+		Name:  "ecbp1100.peers.floor",
+		Usage: "Configure ECBP-1100 (MESS) minimum peer disable limit (below which ECBP1100 will be disabled)",
+		Value: -1,
+	}
+	ECBP1100StaleHeadFlag = cli.DurationFlag{
+		Name:  "ecbp1100.stalehead.ceiling",
+		Usage: "Configure ECBP-1100 (MESS) stale head disable limit (above which ECBP1100 will be disabled)",
+		Value: time.Duration(0),
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -214,6 +214,16 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 	if eth.protocolManager, err = NewProtocolManager(chainConfig, checkpoint, config.SyncMode, config.NetworkId, eth.eventMux, eth.txPool, eth.engine, eth.blockchain, chainDb, cacheLimit, config.Whitelist); err != nil {
 		return nil, err
 	}
+	// Handle configuration overrides for artificial finality features, setting corresponding package globals.
+	if config.ECBP1100MinPeers != nil {
+		log.Warn("Overriding ECBP1100 (MESS) minimum peers requirement", "original", minArtificialFinalityPeers, "target", *config.ECBP1100MinPeers)
+		minArtificialFinalityPeers = *config.ECBP1100MinPeers
+	}
+	if config.ECBP1100StaleHead != nil {
+		log.Warn("Overriding ECBP1100 (MESS) stale head ceiling limit", "original", artificialFinalitySafetyInterval, "target", *config.ECBP1100StaleHead)
+		artificialFinalitySafetyInterval = *config.ECBP1100StaleHead
+	}
+
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -193,4 +193,10 @@ type Config struct {
 
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
 	ECBP1100 *big.Int
+
+	// Minimum peer limit at which ECBP1100 will be disabled.
+	ECBP1100MinPeers *int `toml:",omitempty"`
+
+	// Window at which, if the chain's canonical head is unchanged, ECBP1100 will be disabled.
+	ECBP1100StaleHead *time.Duration `toml:",omitempty"`
 }


### PR DESCRIPTION
Users have requested the ability to manage these limits
with greater granularity.
This exposes 'auto-shutoff' limits to the user.

Defaults are maintained as private (unexposed) values to avoid the suggestion
that users should use these overrides unless they Know What They Are Doing :registered: .

Date: 2021-01-13 11:22:14-06:00
Signed-off-by: meows <b5c6@protonmail.com>