### PR TITLE
.github/workflows: don't build docs on PRs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -10,14 +10,6 @@ on:
       - mkdocs.yml
       - docs/**
       - requirements-mkdocs.txt
-  pull_request:
-    branches:
-      - master
-      - main
-    paths:
-      - mkdocs.yml
-      - docs/**
-      - requirements-mkdocs.txt
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Might fix https://github.com/etclabscore/core-geth/issues/301

Signed-off-by: meows <b5c6@protonmail.com>

---

Should deploy only from changes to master, not on PRs.