### PR TITLE
Feat/ecip1100 force enable

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -170,15 +170,15 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
 		}
 	}
-	if ctx.GlobalIsSet(utils.ECBP1100NoDisableFlag.Name) {
-		if value := ctx.GlobalString(utils.ECBP1100NoDisableFlag.Name); value == "on" {
+	if ctx.GlobalIsSet(utils.ECBP1100ForceFlag.Name) {
+		if value := ctx.GlobalString(utils.ECBP1100ForceFlag.Name); value == "on" {
 			t := true
 			cfg.Eth.ECBP1100StateOverride = &t
 		} else if value == "off" {
 			t := false
 			cfg.Eth.ECBP1100StateOverride = &t
 		} else {
-			log.Crit("invalid value for flag: --%s; use [on|off]", utils.ECBP1100NoDisableFlag.Name)
+			log.Crit("invalid value for flag: --%s; use [on|off]", utils.ECBP1100ForceFlag.Name)
 		}
 	}
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -178,7 +178,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			t := false
 			cfg.Eth.ECBP1100StateOverride = &t
 		} else {
-			log.Crit("invalid value for flag: --%s; use [on|off]", utils.ECBP1100ForceFlag.Name)
+			log.Crit("invalid value for flag", "flag", utils.ECBP1100ForceFlag.Name, "got", value, "want", []string{"on", "off"})
 		}
 	}
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -170,8 +170,16 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
 		}
 	}
-	if ctx.GlobalBool(utils.ECBP1100NoDisableFlag.Name) {
-		cfg.Eth.ECBP1100NoDisable = true
+	if ctx.GlobalIsSet(utils.ECBP1100NoDisableFlag.Name) {
+		if value := ctx.GlobalString(utils.ECBP1100NoDisableFlag.Name); value == "on" {
+			t := true
+			cfg.Eth.ECBP1100StateOverride = &t
+		} else if value == "off" {
+			t := false
+			cfg.Eth.ECBP1100StateOverride = &t
+		} else {
+			log.Crit("invalid value for flag: --%s; use [on|off]", utils.ECBP1100NoDisableFlag.Name)
+		}
 	}
 
 	backend := utils.RegisterEthService(stack, &cfg.Eth)

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -170,6 +170,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
 		}
 	}
+	if ctx.GlobalBool(utils.ECBP1100NoDisableFlag.Name) {
+		cfg.Eth.ECBP1100NoDisable = true
+	}
 
 	backend := utils.RegisterEthService(stack, &cfg.Eth)
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -171,14 +171,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		}
 	}
 	if ctx.GlobalIsSet(utils.ECBP1100ForceFlag.Name) {
-		if value := ctx.GlobalString(utils.ECBP1100ForceFlag.Name); value == "on" {
-			t := true
-			cfg.Eth.ECBP1100StateOverride = &t
-		} else if value == "off" {
-			t := false
-			cfg.Eth.ECBP1100StateOverride = &t
-		} else {
-			log.Crit("invalid value for flag", "flag", utils.ECBP1100ForceFlag.Name, "got", value, "want", []string{"on", "off"})
+		if enable := ctx.GlobalBool(utils.ECBP1100ForceFlag.Name); enable {
+			cfg.Eth.ECBP1100StateOverride = &enable
 		}
 	}
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -169,6 +169,7 @@ var (
 		utils.EWASMInterpreterFlag,
 		utils.EVMInterpreterFlag,
 		utils.ECBP1100Flag,
+		utils.ECBP1100NoDisableFlag,
 		configFileFlag,
 	}
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -169,7 +169,7 @@ var (
 		utils.EWASMInterpreterFlag,
 		utils.EVMInterpreterFlag,
 		utils.ECBP1100Flag,
-		utils.ECBP1100NoDisableFlag,
+		utils.ECBP1100ForceFlag,
 		configFileFlag,
 	}
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -61,6 +61,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,
 			utils.ECBP1100Flag,
+			utils.ECBP1100NoDisableFlag,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -61,7 +61,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,
 			utils.ECBP1100Flag,
-			utils.ECBP1100NoDisableFlag,
+			utils.ECBP1100ForceFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -779,7 +779,7 @@ var (
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,
 	}
-	ECBP1100NoDisableFlag = cli.StringFlag{
+	ECBP1100ForceFlag = cli.StringFlag{
 		Name:  "ecbp1100.force",
 		Usage: "Force ECBP-1100 (MESS) state; valid values are: [on|off] ('on' yields always-on state, disabling auto-shutoff mechanisms; 'off' disables feature entirely)",
 		Value: "",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -779,10 +779,9 @@ var (
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,
 	}
-	ECBP1100ForceFlag = cli.StringFlag{
+	ECBP1100ForceFlag = cli.BoolFlag{
 		Name:  "ecbp1100.force",
-		Usage: "Force ECBP-1100 (MESS) state; valid values are: [on|off] ('on' yields always-on state, disabling auto-shutoff mechanisms; 'off' disables feature entirely)",
-		Value: "",
+		Usage: "Force ECBP-1100 (MESS) state; ('on' yields always-on state, disabling auto-shutoff mechanisms)",
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -779,9 +779,10 @@ var (
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,
 	}
-	ECBP1100NoDisableFlag = cli.BoolTFlag{
-		Name:  "ecbp1100.nodisable",
-		Usage: "Force ECBP-1100 (MESS) enablement; disables min peers and head stale shutoffs",
+	ECBP1100NoDisableFlag = cli.StringFlag{
+		Name:  "ecbp1100.force",
+		Usage: "Force ECBP-1100 (MESS) state; valid values are: [on|off] ('on' yields always-on state, disabling auto-shutoff mechanisms; 'off' disables feature entirely)",
+		Value: "",
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -779,6 +779,10 @@ var (
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,
 	}
+	ECBP1100NoDisableFlag = cli.BoolTFlag{
+		Name:  "ecbp1100.nodisable",
+		Usage: "Force ECBP-1100 (MESS) enablement; disables min peers and head stale shutoffs",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -212,7 +212,8 @@ type BlockChain struct {
 	terminateInsert    func(common.Hash, uint64) bool // Testing hook used to terminate ancient receipt chain insertion.
 	writeLegacyJournal bool                           // Testing flag used to flush the snapshot journal in legacy format.
 
-	artificialFinalityEnabled int32 // toggles artificial finality features
+	artificialFinalityForce         int32 // forces activation of artificial finality features
+	artificialFinalityEnabledStatus int32 // toggles artificial finality features; will be always 1 if artificialFinalityForce=1
 }
 
 // NewBlockChain returns a fully initialised block chain using information

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -212,8 +212,8 @@ type BlockChain struct {
 	terminateInsert    func(common.Hash, uint64) bool // Testing hook used to terminate ancient receipt chain insertion.
 	writeLegacyJournal bool                           // Testing flag used to flush the snapshot journal in legacy format.
 
-	artificialFinalityForce         int32 // forces activation of artificial finality features
-	artificialFinalityEnabledStatus int32 // toggles artificial finality features; will be always 1 if artificialFinalityForce=1
+	artificialFinalityOverride      *int32 // manual override of artificial finality feature activation state
+	artificialFinalityEnabledStatus int32  // toggles artificial finality features; will be always 1 if artificialFinalityForce=1
 }
 
 // NewBlockChain returns a fully initialised block chain using information

--- a/core/blockchain_af.go
+++ b/core/blockchain_af.go
@@ -24,6 +24,12 @@ func (bc *BlockChain) EnableArtificialFinalityForce(n int32) {
 	atomic.StoreInt32(bc.artificialFinalityOverride, n)
 }
 
+// EnableArtificialFinalityStateIsForced return true if artificial finality features have been
+// overridden to be EITHER always-on or always-off.
+func (bc *BlockChain) EnableArtificialFinalityStateIsForced() bool {
+	return bc.artificialFinalityOverride != nil
+}
+
 // EnableArtificialFinality enables and disable artificial finality features for the blockchain.
 // Currently toggled features include:
 // - ECBP1100-MESS: modified exponential subject scoring

--- a/core/blockchain_af.go
+++ b/core/blockchain_af.go
@@ -21,6 +21,7 @@ var errReorgFinality = errors.New("finality-enforced invalid new chain")
 // n != 1 : OFF
 func (bc *BlockChain) EnableArtificialFinalityForce(n int32) {
 	log.Warn("Forcing ECBP1100 (MESS) state", "enabled", n == 1)
+	bc.artificialFinalityOverride = new(int32)
 	atomic.StoreInt32(bc.artificialFinalityOverride, n)
 }
 

--- a/core/blockchain_af.go
+++ b/core/blockchain_af.go
@@ -29,10 +29,10 @@ func (bc *BlockChain) EnableArtificialFinality(enable bool, logValues ...interfa
 	var statusLog string
 	if enable {
 		statusLog = "Enabled"
-		atomic.StoreInt32(&bc.artificialFinalityEnabled, 1)
+		atomic.StoreInt32(&bc.artificialFinalityEnabledStatus, 1)
 	} else {
 		statusLog = "Disabled"
-		atomic.StoreInt32(&bc.artificialFinalityEnabled, 0)
+		atomic.StoreInt32(&bc.artificialFinalityEnabledStatus, 0)
 	}
 	if !bc.chainConfig.IsEnabled(bc.chainConfig.GetECBP1100Transition, bc.CurrentHeader().Number) {
 		// Don't log anything if the config hasn't enabled it yet.
@@ -49,7 +49,7 @@ func (bc *BlockChain) EnableArtificialFinality(enable bool, logValues ...interfa
 // finality feature setting.
 // This status is agnostic of feature activation by chain configuration.
 func (bc *BlockChain) IsArtificialFinalityEnabled() bool {
-	return atomic.LoadInt32(&bc.artificialFinalityEnabled) == 1
+	return atomic.LoadInt32(&bc.artificialFinalityEnabledStatus) == 1
 }
 
 // getTDRatio is a helper function returning the total difficulty ratio of

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -195,6 +195,10 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 		rawdb.WriteChainConfig(chainDb, genesisHash, chainConfig)
 	}
 	eth.bloomIndexer.Start(eth.blockchain)
+	// Handle artificial finality config override cases.
+	if config.ECBP1100NoDisable {
+		eth.blockchain.EnableArtificialFinalityForce(1)
+	}
 
 	if config.TxPool.Journal != "" {
 		config.TxPool.Journal = stack.ResolvePath(config.TxPool.Journal)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -196,8 +196,12 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 	}
 	eth.bloomIndexer.Start(eth.blockchain)
 	// Handle artificial finality config override cases.
-	if config.ECBP1100NoDisable {
-		eth.blockchain.EnableArtificialFinalityForce(1)
+	if config.ECBP1100StateOverride != nil {
+		stateOn := int32(1)
+		if !*config.ECBP1100StateOverride {
+			stateOn = 0
+		}
+		eth.blockchain.EnableArtificialFinalityForce(stateOn)
 	}
 
 	if config.TxPool.Journal != "" {

--- a/eth/config.go
+++ b/eth/config.go
@@ -193,4 +193,8 @@ type Config struct {
 
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
 	ECBP1100 *big.Int
+
+	// ECBP1100NoDisable prevents shutoff mechanisms based on min peer count and head staleness window.
+	// When this value is true, ECBP100 will not (ever) be disabled.
+	ECBP1100NoDisable bool `toml:",omitempty"`
 }

--- a/eth/config.go
+++ b/eth/config.go
@@ -194,7 +194,7 @@ type Config struct {
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
 	ECBP1100 *big.Int
 
-	// ECBP1100NoDisable prevents shutoff mechanisms based on min peer count and head staleness window.
-	// When this value is true, ECBP100 will not (ever) be disabled.
-	ECBP1100NoDisable bool `toml:",omitempty"`
+	// ECBP1100StateOverride overrides
+	// When this value is *true, ECBP100 will not (ever) be disabled; when *false, it will never be enabled.
+	ECBP1100StateOverride *bool `toml:",omitempty"`
 }

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -66,14 +66,6 @@ type txsync struct {
 func (pm *ProtocolManager) artificialFinalitySafetyLoop() {
 	defer pm.wg.Done()
 
-	// Short circuit if configuration overrides are present to permanently
-	// enable or disable artificial finality features.
-	// This isn't strictly-speaking necessary since the toggle will be a noop if the state is forced,
-	// but returning early spares the additional goroutine.
-	if pm.blockchain.EnableArtificialFinalityStateIsForced() {
-		return
-	}
-
 	t := time.NewTicker(artificialFinalitySafetyInterval)
 	defer t.Stop()
 


### PR DESCRIPTION
This is an alternative to #299. Where 299 exposes ECBP1100's auto-shutoff limits to the user as configuration options, this approach instead exposes a configuration option `--ecbp1100.force=[on|off]`.

This is
- simpler (from the user perspective)
- logically (in code) more direct and forceful; rather than mutating the variables of existing conditions, the state of ECBP1100 is force-set to `1 == on` and `0 == off`. 

Existing toggle methods are allowed to maintain their call logic, but their handler `func (bc *BlockChain) EnableArtificialFinality(enable bool, logValues ...interface{})` short-circuits if the force state is active. 