### PR TITLE
Release/v1.11.21

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 11       // Minor version component of the current release
-	VersionPatch = 21       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 11         // Minor version component of the current release
+	VersionPatch = 22         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 11         // Minor version component of the current release
-	VersionPatch = 21         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 11       // Minor version component of the current release
+	VersionPatch = 21       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
### Release notes (pending)

- __Add__ `--ecbp1100.nodisable` as a mechanism to disable ECBP1100 auto-shutoff mechanisms (low peers and stale head) (#303).
- __Add__ a new RPC API subscription method `newSideBlocks` (Websocket, IPC, and `inproc` only), creating a subscription to side-chain import events (blocks written but not considered canonical) (#293).
- __Add__ OpenRPC `rpc.discover` schema compliance tests (#295).
- __Refactor__ `cmd/faucet` to fix some bugs and add some features, including...
  - __Add__ `faucet --attach` flag to allow you to run a faucet on top of an existing node instance (instead of only on top of a dedicated light client) (#269).
  - __Add__ `faucet --syncmode` flag to allow you to pick the syncmode if you want the faucet to manage it's own node (#268).
  - __Migrate__ the faucet's node data directory (if any) from `<datadir>/MultiFaucet` to `<datadir>/CoreFaucet`. The data migration logic should handle this automatically for you, but if you're using a custom setup you may need to reconfigure (#279).
- __Fix__ a `geth console` bug where `--jspath` and `--preload` together would generate a bad path (#274).
- __Remove__ `cmd/puppeth` to reduce footprint and trim feature-creep (#270).
- Finally set up a __documentation site__, check it out!  __https://etclabscore.github.io/core-geth__  📕 :tada:
  (#291, #294, #300)

---

- Docker images published under [`etclabscore/core-geth`](https://hub.docker.com/r/etclabscore/core-geth/builds).