### PR TITLE
Fix discovery external docs URL

### DIFF
--- a/node/openrpc.go
+++ b/node/openrpc.go
@@ -182,6 +182,21 @@ func newOpenRPCDocument() *go_openrpc_reflect.Document {
 		return go_openrpc_reflect.EthereumReflector.GetContentDescriptorRequired(r, m, field)
 	}
 
+	appReflector.FnGetMethodExternalDocs = func(r reflect.Value, m reflect.Method, funcDecl *ast.FuncDecl) (*meta_schema.ExternalDocumentationObject, error) {
+		standard := go_openrpc_reflect.StandardReflector
+		got, err := standard.GetMethodExternalDocs(r, m, funcDecl)
+		if err != nil {
+			return nil, err
+		}
+		if got.Url == nil {
+			return got, nil
+		}
+		// Replace links to go-ethereum repo with current core-geth one
+		newLink := meta_schema.ExternalDocumentationObjectUrl(strings.Replace(string(*got.Url), "github.com/ethereum/go-ethereum", "github.com/etclabscore/core-geth", 1))
+		got.Url = &newLink
+		return got, nil
+	}
+
 	// Finally, register the configured reflector to the document.
 	d.WithReflector(appReflector)
 	return d

--- a/node/openrpc.go
+++ b/node/openrpc.go
@@ -56,7 +56,12 @@ var sharedMetaRegisterer = &go_openrpc_reflect.MetaT{
 		return info
 	},
 	GetExternalDocsFn: func() (exdocs *meta_schema.ExternalDocumentationObject) {
-		return nil // FIXME
+		exdocs = &meta_schema.ExternalDocumentationObject{}
+		description := "ETC Labs Documentation"
+		exdocs.Description = (*meta_schema.ExternalDocumentationObjectDescription)(&description)
+		url := "https://etclabscore.github.io/core-geth/"
+		exdocs.Url = (*meta_schema.ExternalDocumentationObjectUrl)(&url)
+		return exdocs
 	},
 }
 


### PR DESCRIPTION
The RPC discovery document was returning links to GitHub repo of `ethereum/go-ethereum`. This PR makes those links, link back to our `etclabscore/core-geth` repo.

On top of that, this PR also adds link to our [documentation site](https://etclabscore.github.io/core-geth/) for the whole discovery document. This link has to be updated to the final page made available by #306.


Fixes #297 