### PR TITLE
eth: update default extraData

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -250,7 +250,7 @@ func makeExtraData(extra []byte) []byte {
 		// create default extradata
 		extra, _ = rlp.EncodeToBytes([]interface{}{
 			uint(params.VersionMajor<<16 | params.VersionMinor<<8 | params.VersionPatch),
-			"geth",
+			"CoreGeth",
 			runtime.Version(),
 			runtime.GOOS,
 		})

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -1,0 +1,12 @@
+package eth
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMakeExtraDataDefault(t *testing.T) {
+	if !bytes.Contains(makeExtraData(nil), []byte("CoreGeth")) {
+		t.Error("missing extra data default client identifier")
+	}
+}


### PR DESCRIPTION
updates the default extraData field, from geth -> CoreGeth to be consistent with both `geth version` and ethstats.