### PR TITLE
eth: add stale check before allowing re-enable of AF by sync status

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -309,8 +309,13 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	op := peerToSyncOp(mode, peer)
 	if op.td.Cmp(ourTD) <= 0 {
 		// Enable artificial finality if parameters if should.
+		// - In full sync mode.
 		if op.mode == downloader.FullSync &&
+			// - Have enough peers.
 			cs.pm.peers.Len() >= minArtificialFinalityPeers &&
+			// - Head is not stale.
+			!(time.Since(time.Unix(int64(cs.pm.blockchain.CurrentHeader().Time), 0)) > artificialFinalitySafetyInterval) &&
+			// - AF is disabled (so we should reenable).
 			!cs.pm.blockchain.IsArtificialFinalityEnabled() {
 			cs.pm.blockchain.EnableArtificialFinality(true, "reason", "synced", "peers", cs.pm.peers.Len())
 		}

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -21,11 +21,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/params"
 )
+
+// blockGenContemporaryTime creates a block gen function that will bump the block times to within throwing
+// distance of the current time.
+// Without this, block times are built on a genesis with a 0 (or 10) timestamp, which is in 1970.
+// This causes the apparent age of the chain to exceed the safety interval and thus interferes with
+// reasonable expectations of staleness.
+func blockGenContemporaryTime(numBlocks int64) func(i int, gen *core.BlockGen) {
+	startTimeUnix := time.Now().Unix()
+	return func(i int, gen *core.BlockGen) {
+		if i == 0 {
+			// Here, 1024 is the max number of block we'll create.
+			// 10 is the magic number that the test helper block gen will use for the block time offsets.
+			gen.OffsetTime(startTimeUnix - (numBlocks * 10))
+		}
+	}
+}
 
 func TestFastSyncDisabling63(t *testing.T) { testFastSyncDisabling(t, 63) }
 func TestFastSyncDisabling64(t *testing.T) { testFastSyncDisabling(t, 64) }
@@ -36,13 +53,16 @@ func TestFastSyncDisabling65(t *testing.T) { testFastSyncDisabling(t, 65) }
 func testFastSyncDisabling(t *testing.T, protocol int) {
 	t.Parallel()
 
+	maxBlocksCreated := 1024
+	genFunc := blockGenContemporaryTime(int64(maxBlocksCreated))
+
 	// Create a pristine protocol manager, check that fast sync is left enabled
-	pmEmpty, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, nil, nil)
+	pmEmpty, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, genFunc, nil)
 	if atomic.LoadUint32(&pmEmpty.fastSync) == 0 {
 		t.Fatalf("fast sync disabled on pristine blockchain")
 	}
 	// Create a full protocol manager, check that fast sync gets disabled
-	pmFull, _ := newTestProtocolManagerMust(t, downloader.FastSync, 1024, nil, nil)
+	pmFull, _ := newTestProtocolManagerMust(t, downloader.FastSync, maxBlocksCreated, genFunc, nil)
 	if atomic.LoadUint32(&pmFull.fastSync) == 1 {
 		t.Fatalf("fast sync not disabled on non-empty blockchain")
 	}
@@ -65,8 +85,11 @@ func testFastSyncDisabling(t *testing.T, protocol int) {
 }
 
 func TestArtificialFinalityFeatureEnablingDisabling(t *testing.T) {
+	maxBlocksCreated := 1024
+	genFunc := blockGenContemporaryTime(int64(maxBlocksCreated))
+
 	// Create a full protocol manager, check that fast sync gets disabled
-	a, _ := newTestProtocolManagerMust(t, downloader.FastSync, 1024, nil, nil)
+	a, _ := newTestProtocolManagerMust(t, downloader.FastSync, maxBlocksCreated, genFunc, nil)
 	if atomic.LoadUint32(&a.fastSync) == 1 {
 		t.Fatalf("fast sync not disabled on non-empty blockchain")
 	}
@@ -82,7 +105,7 @@ func TestArtificialFinalityFeatureEnablingDisabling(t *testing.T) {
 	minArtificialFinalityPeers = 1
 
 	// Create a full protocol manager, check that fast sync gets disabled
-	b, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, nil, nil)
+	b, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, genFunc, nil)
 	if atomic.LoadUint32(&b.fastSync) == 0 {
 		t.Fatalf("fast sync disabled on pristine blockchain")
 	}
@@ -128,8 +151,11 @@ func TestArtificialFinalityFeatureEnablingDisabling(t *testing.T) {
 // TestArtificialFinalityFeatureEnablingDisabling_NoDisable tests that when the nodisable override
 // is in place (see NOTE1 below), AF is not disabled at the min peer floor.
 func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
+	maxBlocksCreated := 1024
+	genFunc := blockGenContemporaryTime(int64(maxBlocksCreated))
+
 	// Create a full protocol manager, check that fast sync gets disabled
-	a, _ := newTestProtocolManagerMust(t, downloader.FastSync, 1024, nil, nil)
+	a, _ := newTestProtocolManagerMust(t, downloader.FastSync, maxBlocksCreated, genFunc, nil)
 	if atomic.LoadUint32(&a.fastSync) == 1 {
 		t.Fatalf("fast sync not disabled on non-empty blockchain")
 	}
@@ -145,7 +171,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 	minArtificialFinalityPeers = 1
 
 	// Create a full protocol manager, check that fast sync gets disabled
-	b, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, nil, nil)
+	b, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, genFunc, nil)
 	if atomic.LoadUint32(&b.fastSync) == 0 {
 		t.Fatalf("fast sync disabled on pristine blockchain")
 	}
@@ -168,6 +194,11 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 
 	b.chainSync.forced = true
 	next := b.chainSync.nextSyncOp()
+
+	// Revert safety condition overrides to default values.
+	// Set the value back to default (more than 1).
+	minArtificialFinalityPeers = oMinAFPeers
+
 	if next != nil {
 		t.Fatal("non-nil next sync op")
 	}
@@ -177,9 +208,6 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 	if !b.blockchain.IsArtificialFinalityEnabled() {
 		t.Error("AF not enabled")
 	}
-
-	// Set the value back to default (more than 1).
-	minArtificialFinalityPeers = oMinAFPeers
 
 	// Next sync op will unset AF because manager only has 1 peer.
 	b.chainSync.forced = true
@@ -192,6 +220,70 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 The AF disable mechanism triggered by the minimum peers floor should have been short-circuited,
 preventing AF disablement on this sync op (with the minArtificialFinalityPeers value set to > 1 (defaultMinSyncPeers = 5)),
 and the number of peers 'a' is connected with being only 1.)`)
+	}
+}
+
+// TestArtificialFinalityFeatureEnablingDisabling_StaleHead tests that the stale head condition is respected.
+// The block generator function will yield a chain with a head, which because of it time=0 (aka year 1970) genesis, will
+// be very old (far exceeding the auto-disable stale limit).
+// In this case, AF features should NOT be enabled.
+func TestArtificialFinalityFeatureEnablingDisabling_StaleHead(t *testing.T) {
+	maxBlocksCreated := 1024
+
+	// Create a full protocol manager, check that fast sync gets disabled
+	a, _ := newTestProtocolManagerMust(t, downloader.FastSync, maxBlocksCreated, nil, nil)
+	if atomic.LoadUint32(&a.fastSync) == 1 {
+		t.Fatalf("fast sync not disabled on non-empty blockchain")
+	}
+
+	one := uint64(1)
+	a.blockchain.Config().SetECBP1100Transition(&one)
+
+	oMinAFPeers := minArtificialFinalityPeers
+	defer func() {
+		// Clean up after, resetting global default to original value.
+		minArtificialFinalityPeers = oMinAFPeers
+	}()
+	minArtificialFinalityPeers = 1
+
+	// Create a full protocol manager, check that fast sync gets disabled
+	b, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, nil, nil)
+	if atomic.LoadUint32(&b.fastSync) == 0 {
+		t.Fatalf("fast sync disabled on pristine blockchain")
+	}
+	b.blockchain.Config().SetECBP1100Transition(&one)
+
+	io1, io2 := p2p.MsgPipe()
+	go a.handle(a.newPeer(65, p2p.NewPeer(enode.ID{}, "peer-b", nil), io2, a.txpool.Get))
+	go b.handle(b.newPeer(65, p2p.NewPeer(enode.ID{}, "peer-a", nil), io1, b.txpool.Get))
+	time.Sleep(250 * time.Millisecond)
+
+	op := peerToSyncOp(downloader.FullSync, b.peers.BestPeer())
+	if err := b.doSync(op); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	b.chainSync.forced = true
+	next := b.chainSync.nextSyncOp()
+
+	// Revert safety condition overrides to default values.
+	// Set the value back to default (more than 1).
+	minArtificialFinalityPeers = oMinAFPeers
+
+	if next != nil {
+		t.Fatal("non-nil next sync op")
+	}
+	if !b.blockchain.Config().IsEnabled(b.blockchain.Config().GetECBP1100Transition, b.blockchain.CurrentBlock().Number()) {
+		t.Error("AF feature not configured")
+	}
+	// Unit test the timestamp. We want to be sure that the blockchain's current header is actually very old
+	// (since we expect its age to act as a condition preventing the enabling of AF features).
+	d := uint64(time.Now().Unix()) - b.blockchain.CurrentHeader().Time
+	if time.Second*time.Duration(d) < artificialFinalitySafetyInterval {
+		t.Errorf("Expected blockchain current head to be very old, it is not.")
+	}
+	if b.blockchain.IsArtificialFinalityEnabled() {
+		t.Error("AF is enabled despite a very stale head")
 	}
 }
 


### PR DESCRIPTION
Mordor showed a scenario where despite a stale head,
sync achievement would re-enable AF features.

This causes the sync-status reenablement to
respect the stale head condition.

Date: 2021-02-22 06:19:13-06:00
Signed-off-by: meows <b5c6@protonmail.com>