### PR TITLE
Feat/audit bootnodes ci

### DIFF
--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -61,10 +61,11 @@ jobs:
               fi
             done
           done < <(find ./params -type f -name '*bootnode*go')
+          test $status -eq 0 || git --no-pager diff
           exit $status
 
       - name: Create Pull Request
-        if: github.event_name == 'schedule'
+        if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: 'params: remove unresponsive bootnodes'

--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -73,5 +73,5 @@ jobs:
           body: |
             These bootnodes did not respond to `./build/bin/devp2p discv4 ping` requests.
 
-            For details: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}.
+            For details: ${{github.github_server_url}}/${{github.github_repository}}/actions/runs/${{github.github_run_id}}.
           branch: remove-stale-bootnodes

--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -1,0 +1,82 @@
+name: Audit Bootnodes
+
+on:
+
+  schedule:
+    - cron: '0 6 * * *'
+
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - 'params/bootnode*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    name: Audit Bootnodes
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          git submodule update --init --recursive
+          go get golang.org/x/mobile/cmd/gomobile
+          gomobile init
+
+      - name: Build
+        run: |
+          make all
+
+      - name: Audit Bootnodes
+        shell: bash
+        run: |
+          healthcheck() {
+            enode_list="$(cat "$1" |grep -E 'enode://' | sed 's-"--g' | sed 's-\t--g'| sed 's/,.*//g')"
+            echo "$enode_list" | while read -r line; do
+              if 2>/dev/null ./build/bin/devp2p discv4 ping "${line}"; then
+                >&2 echo "PASS: ${line}"
+              else
+                echo "${line}"
+              fi
+            done
+          }
+          status=0
+          while read -r file; do
+            echo "Auditing ${file}"
+            healthcheck "${file}" | while read -r failed; do
+              echo "FAIL: ${fail}"
+              if [[ $GITHUB_EVENT_NAME != pull_request ]]; then
+                id="$(basename ${fail} | cut -d'@' -f1)"
+                sed -i '/'"${id}"'/d' "${file}"
+              else
+                status=1
+              fi
+            done
+          done < <(find ./params -type f -name '*bootnode*go')
+          exit $status
+
+      - name: Create Pull Request
+        if: github.event_name == 'schedule'
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: 'params: remove unresponsive bootnodes'
+          title: 'params: remove unresponsive bootnodes'
+          body: |
+            These bootnodes did not respond to `discv4 ping` requests.
+
+            For details: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID.
+          branch: remove-stale-bootnodes

--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -73,5 +73,5 @@ jobs:
           body: |
             These bootnodes did not respond to `./build/bin/devp2p discv4 ping` requests.
 
-            For details: ${{github.github_server_url}}/${{github.github_repository}}/actions/runs/${{github.github_run_id}}.
+            For details: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}.
           branch: remove-stale-bootnodes

--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -29,10 +29,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
 
-      - name: Build devp2p
+      - name: Build bin/devp2p
         run: |
           mkdir -p build/bin
           go build -o build/bin/devp2p ./cmd/devp2p
@@ -43,7 +41,7 @@ jobs:
           healthcheck() {
             enode_list="$(cat "$1" |grep -E 'enode://' | sed 's-"--g' | sed 's-\t--g'| sed 's/,.*//g')"
             echo "$enode_list" | while read -r line; do
-              if 2>/dev/null ./build/bin/devp2p discv4 ping "${line}"; then
+              if >/dev/null 2>&1 ./build/bin/devp2p discv4 ping "${line}"; then
                 >&2 echo "PASS: ${line}"
               else
                 echo "${line}"

--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -29,17 +29,13 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
 
-      - name: Get dependencies
+      - name: Build devp2p
         run: |
-          go get -v -t -d ./...
-          git submodule update --init --recursive
-          go get golang.org/x/mobile/cmd/gomobile
-          gomobile init
-
-      - name: Build
-        run: |
-          make all
+          mkdir -p build/bin
+          go build -o build/bin/devp2p ./cmd/devp2p
 
       - name: Audit Bootnodes
         shell: bash
@@ -58,9 +54,9 @@ jobs:
           while read -r file; do
             echo "Auditing ${file}"
             healthcheck "${file}" | while read -r failed; do
-              echo "FAIL: ${fail}"
+              echo "FAIL: ${failed}"
               if [[ $GITHUB_EVENT_NAME != pull_request ]]; then
-                id="$(basename ${fail} | cut -d'@' -f1)"
+                id="$(basename ${failed} | cut -d'@' -f1)"
                 sed -i '/'"${id}"'/d' "${file}"
               else
                 status=1

--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -61,7 +61,7 @@ jobs:
               fi
             done
           done < <(find ./params -type f -name '*bootnode*go')
-          test $status -eq 0 || git --no-pager diff
+          test "$GITHUB_EVENT_NAME" -ne "pull_request" && git --no-pager diff
           exit $status
 
       - name: Create Pull Request
@@ -71,7 +71,7 @@ jobs:
           commit-message: 'params: remove unresponsive bootnodes'
           title: 'params: remove unresponsive bootnodes'
           body: |
-            These bootnodes did not respond to `discv4 ping` requests.
+            These bootnodes did not respond to `./build/bin/devp2p discv4 ping` requests.
 
-            For details: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID.
+            For details: ${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}.
           branch: remove-stale-bootnodes


### PR DESCRIPTION
Rel #321

Installs a Github Actions CI Workflow that audits the bootnodes listed as chain configuration defaults (for all chains).

It uses `./build/bin/devp2p discv4 ping`, pinging each enode. Nodes that respond pass, nodes that fail to respond... well, they fail. _You had one job...._

The workflow is configured to run
- as a cron job, once daily
- on pull requests that edit `params/bootnodes*go`
- or manually (via `workflow_dispatch`)

For `schedule` (cron) and `workflow_dispatch` triggers, the workflow will remove failing enodes and create a pull request with that change set.

For `pull_request` triggers, the action will _not_ create a PR; it will just just fail and the light will turn red :x:.

As for the actual outcome of auditing the bootnodes, a complementary PR is here: https://github.com/meowsbits/core-geth/pull/15.