### PR TITLE
.github/workflows: bump EVMC CI Go environment to go1.16 (from 1.13)

### DIFF
--- a/.github/workflows/evmc.yml
+++ b/.github/workflows/evmc.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/evmc.yml
+++ b/.github/workflows/evmc.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: ^1.15
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
Date: 2021-03-02 06:00:03-06:00
Signed-off-by: meows <b5c6@protonmail.com>