### PR TITLE
bump Travis and Appveyor ci Go version to go1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,31 +18,19 @@ jobs:
 
   # Run core-geth -specific tests, proving regression-safety and config interoperability.
   - stage: build
-    name: "Go1.15.x: make test-coregeth"
+    name: "Go1.16.x: make test-coregeth"
     os: linux
     dist: xenial
-    go: 1.15.x
+    go: 1.16.x
     script:
     - make test-coregeth
 
   # Run build and tests against latest-1 Go version.
   - stage: build
-    name: "Go1.13.x: make test"
+    name: "Go1.15.x: make test"
     os: linux
     dist: xenial
-    go: 1.13.x
-    env:
-      - GO111MODULE=on
-    script:
-      - make all
-      - travis_wait 60 make test
-
-    # Run build and tests against latest-1 Go version.
-  - stage: build
-    name: "Go1.14.x: make test"
-    os: linux
-    dist: xenial
-    go: 1.14.x
+    go: 1.15.x
     env:
       - GO111MODULE=on
     script:
@@ -56,7 +44,7 @@ jobs:
     os: linux
     arch: arm64
     dist: xenial
-    go: 1.15.x
+    go: 1.16.x
     env:
       - GO111MODULE=on
     script:
@@ -66,10 +54,10 @@ jobs:
   # Run build and tests with environment-aware possible artifact deployment.
   - stage: build
     if: type = push
-    name: "Go1.15.x: make test && deploy"
+    name: "Go1.16.x: make test && deploy"
     os: linux
     dist: xenial
-    go: 1.15.x
+    go: 1.16.x
     script:
     - go run build/ci.go install -dlgo
     - travis_wait 60 make test
@@ -91,11 +79,11 @@ jobs:
   # Run build on ARM5 with environment-aware possible artifact deployment.
   - stage: build
     if: type = push
-    name: "ARM5/Go1.15.x: go run build/ci.go install && deploy"
+    name: "ARM5/Go1.16.x: go run build/ci.go install && deploy"
     os: linux
     dist: xenial
     sudo: required
-    go: 1.15.x
+    go: 1.16.x
     env:
       - ARMv5
     git:
@@ -127,9 +115,9 @@ jobs:
   #Run build on OSX with environment-aware possible artifact deployment.
   - stage: build
     if: type = push
-    name: "OSX/Go1.15.x: make all && deploy"
+    name: "OSX/Go1.16.x: make all && deploy"
     os: osx
-    go: 1.15.x
+    go: 1.16.x
     script:
     - echo "Increase the maximum number of open file descriptors on macOS"
     - NOFILE=20480

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
   - stage: lint
     os: linux
     dist: xenial
-    go: 1.15.x
+    go: 1.16.x
     env:
       - lint
     git:

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -1746,11 +1746,20 @@ func TestGolangBindings(t *testing.T) {
 		t.Fatalf("failed to convert binding test to modules: %v\n%s", err, out)
 	}
 	pwd, _ := os.Getwd()
-	replacer := exec.Command(gocmd, "mod", "edit", "-replace", "github.com/ethereum/go-ethereum="+filepath.Join(pwd, "..", "..", "..")) // Repo root
+	repoRoot := filepath.Join(pwd, "..", "..", "..")
+
+	replacer := exec.Command(gocmd, "mod", "edit", "-replace", "github.com/ethereum/go-ethereum="+repoRoot) // Repo root
 	replacer.Dir = pkg
 	if out, err := replacer.CombinedOutput(); err != nil {
-		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
+		t.Fatalf("failed to replace binding test 'replace' dependency to current source tree: %v\n%s", err, out)
 	}
+
+	tidyer := exec.Command(gocmd, "mod", "tidy")
+	tidyer.Dir = pkg
+	if out, err := tidyer.CombinedOutput(); err != nil {
+		t.Fatal(err, string(out))
+	}
+
 	// Test the entire package and report any failures
 	cmd := exec.Command(gocmd, "test", "-v", "-count", "1")
 	cmd.Dir = pkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.15.5.windows-%GETH_ARCH%.zip
-  - 7z x go1.15.5.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://dl.google.com/go/go1.16.windows-%GETH_ARCH%.zip
+  - 7z x go1.16.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 


### PR DESCRIPTION
I upgraded to Go 1.16 and got an error when running the tests; the following log shows:
- the solved case with tests passing,
- commented the fix and show the `git diff`
- re-run tests and show that it fails (and how it fails) without this fix

Note that when upgrading to `go1.16`, there may be associated issues  that can be resolved by running `make clean`, which calls `go clean -cache`.

```
8a83 03-02 06:41:13 ~/go/src/github.com/ethereum/go-ethereum fix/go1.16-accounts-bind-tests-pr *
rm -rf ./build/_workspace/pkg/ && go test ./accounts/...
ok      github.com/ethereum/go-ethereum/accounts        (cached)
ok      github.com/ethereum/go-ethereum/accounts/abi    (cached)
ok      github.com/ethereum/go-ethereum/accounts/abi/bind       (cached)
ok      github.com/ethereum/go-ethereum/accounts/abi/bind/backends      (cached)
?       github.com/ethereum/go-ethereum/accounts/external       [no test files]
ok      github.com/ethereum/go-ethereum/accounts/keystore       (cached)
?       github.com/ethereum/go-ethereum/accounts/scwallet       [no test files]
?       github.com/ethereum/go-ethereum/accounts/usbwallet      [no test files]
?       github.com/ethereum/go-ethereum/accounts/usbwallet/trezor       [no test files]
1aef 03-02 06:41:23 ~/go/src/github.com/ethereum/go-ethereum fix/go1.16-accounts-bind-tests-pr
git --no-pager diff
diff --git a/accounts/abi/bind/bind_test.go b/accounts/abi/bind/bind_test.go
index dfeb5b9e50..c5b4d61de9 100644
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -1754,11 +1754,11 @@ func TestGolangBindings(t *testing.T) {
                t.Fatalf("failed to replace binding test 'replace' dependency to current source tree: %v\n%s", err, out)
        }

-       tidyer := exec.Command(gocmd, "mod", "tidy")
-       tidyer.Dir = pkg
-       if out, err := tidyer.CombinedOutput(); err != nil {
-               t.Fatal(err, string(out))
-       }
+       // tidyer := exec.Command(gocmd, "mod", "tidy")
+       // tidyer.Dir = pkg
+       // if out, err := tidyer.CombinedOutput(); err != nil {
+       //      t.Fatal(err, string(out))
+       // }

        // Test the entire package and report any failures
        cmd := exec.Command(gocmd, "test", "-v", "-count", "1")
3125 03-02 06:41:34 ~/go/src/github.com/ethereum/go-ethereum fix/go1.16-accounts-bind-tests-pr *
rm -rf ./build/_workspace/pkg/ && go test ./accounts/...
ok      github.com/ethereum/go-ethereum/accounts        (cached)
ok      github.com/ethereum/go-ethereum/accounts/abi    (cached)
--- FAIL: TestGolangBindings (0.14s)
    bind_test.go:1767: failed to run binding test: exit status 1
        callbackparam.go:10:2: module github.com/ethereum/go-ethereum provides package github.com/ethereum/go-ethereum and is replaced but not required; to add it:
                go get github.com/ethereum/go-ethereum
        callbackparam.go:11:2: module github.com/ethereum/go-ethereum provides package github.com/ethereum/go-ethereum/accounts/abi and is replaced but not required; to add it:
                go get github.com/ethereum/go-ethereum
        callbackparam.go:12:2: module github.com/ethereum/go-ethereum provides package github.com/ethereum/go-ethereum/accounts/abi/bind and is replaced but not required; to add it:
                go get github.com/ethereum/go-ethereum
        callbackparam.go:13:2: module github.com/ethereum/go-ethereum provides package github.com/ethereum/go-ethereum/common and is replaced but not required; to add it:
                go get github.com/ethereum/go-ethereum
        callbackparam.go:14:2: module github.com/ethereum/go-ethereum provides package github.com/ethereum/go-ethereum/core/types and is replaced but not required; to add it:
                go get github.com/ethereum/go-ethereum
        callbackparam.go:15:2: module github.com/ethereum/go-ethereum provides package github.com/ethereum/go-ethereum/event and is replaced but not required; to add it:
                go get github.com/ethereum/go-ethereum
FAIL
FAIL    github.com/ethereum/go-ethereum/accounts/abi/bind       0.170s
ok      github.com/ethereum/go-ethereum/accounts/abi/bind/backends      (cached)
?       github.com/ethereum/go-ethereum/accounts/external       [no test files]
ok      github.com/ethereum/go-ethereum/accounts/keystore       (cached)
?       github.com/ethereum/go-ethereum/accounts/scwallet       [no test files]
?       github.com/ethereum/go-ethereum/accounts/usbwallet      [no test files]
?       github.com/ethereum/go-ethereum/accounts/usbwallet/trezor       [no test files]
FAIL
7b6e 03-02 06:43:18 ~/go/src/github.com/ethereum/go-ethereum fix/go1.16-accounts-bind-tests-pr
go version
go version go1.16 linux/amd64

```