### PR TITLE
.travis.yml: divide arm job into alphabetical segments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ jobs:
       - travis_wait 60 make test
 
   # Run build and tests on ARM64 on Pull Requests.
+  # These tests are divided in half because their aggregate typical runtime
+  # exceeds Travis' time limit (~60m) and were consistently causing timeouts.
   - stage: build
     name: "ARM64/Go1.15.x: make test [A-G]"
     if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
 
   # Run build and tests on ARM64 on Pull Requests.
   - stage: build
-    name: "ARM64/Go1.15.x: make test"
+    name: "ARM64/Go1.15.x: make test [A-G]"
     if: type = pull_request
     os: linux
     arch: arm64
@@ -60,8 +60,18 @@ jobs:
     env:
       - GO111MODULE=on
     script:
-      - go run build/ci.go install -dlgo
-      - travis_wait 60 make test
+      - go run build/ci.go test -coverage $(printf './%s/... ' $(go list ./... | sed 's|github.com/ethereum/go-ethereum||g' | cut -d'/' -f2 | uniq | grep -E '^[a-g]'))
+  - stage: build
+    name: "ARM64/Go1.15.x: make test [H-Z]"
+    if: type = pull_request
+    os: linux
+    arch: arm64
+    dist: xenial
+    go: 1.15.x
+    env:
+      - GO111MODULE=on
+    script:
+      - go run build/ci.go test -coverage $(printf './%s/... ' $(go list ./... | sed 's|github.com/ethereum/go-ethereum||g' | cut -d'/' -f2 | uniq | grep -E '^[h-z]'))
 
   # Run build and tests with environment-aware possible artifact deployment.
   - stage: build

--- a/docs/JSON-RPC-API/openrpc.md
+++ b/docs/JSON-RPC-API/openrpc.md
@@ -7,7 +7,7 @@ hide:
 # OpenRPC
 
 !!! tldr "TLDR"
-    The `rpc.discover` returns an API service description structured per the [OpenRPC specification](https://github.com/open-rpc/spec/blob/master/spec.md). 
+    The `rpc.discover` method returns an API service description structured per the [OpenRPC specification](https://github.com/open-rpc/spec/blob/master/spec.md). 
 
 ## Discovery
 


### PR DESCRIPTION
This job times out consistently.

This solution divides the task of running the repo's
tests into two pieces; one running the tests for packages
that begin with A-G, and the other for packages starting
with H-Z (which are approximately equal number of tests).

Fixes #327. 

The impacted job as run for this PR is here: https://travis-ci.org/github/etclabscore/core-geth/builds/761274000.

![image](https://user-images.githubusercontent.com/45600330/109848697-295cbb80-7c16-11eb-887d-163c2bbd7289.png)

Date: 2021-03-03 05:33:14-06:00
Signed-off-by: meows <b5c6@protonmail.com>