### PR TITLE
internal/ethapi: don't omit empty txes, uncles from getBlock responses

### DIFF
--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -277,6 +277,43 @@ func TestHeader(t *testing.T) {
 	}
 }
 
+func TestHeader_TxesUnclesNotEmpty(t *testing.T) {
+	backend, _ := newTestBackend(t)
+	client, _ := backend.Attach()
+	defer backend.Close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	res := make(map[string]interface{})
+	err := client.CallContext(ctx, &res, "eth_getBlockByNumber", "latest", false)
+	if err == nil && res == nil {
+		err = ethereum.NotFound
+	}
+
+	// Sanity check response
+	if v, ok := res["number"]; !ok {
+		t.Fatal("missing 'number' field")
+	} else if n, err := hexutil.DecodeBig(v.(string)); err != nil || n == nil {
+		t.Fatal(err)
+	} else if n.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("unexpected 'latest' block number: %v", n)
+	}
+	// 'transactions' key should exist as []
+	if v, ok := res["transactions"]; !ok {
+		t.Fatal("missing transactions field")
+	} else if len(v.([]interface{})) != 0 {
+		t.Fatal("'transactions' value not []")
+	}
+	// 'uncles' key should exist as []
+	if v, ok := res["uncles"]; !ok {
+		t.Fatal("missing uncles field")
+	} else if len(v.([]interface{})) != 0 {
+		t.Fatal("'uncles' value not []'")
+	}
+}
+
 func TestBalanceAt(t *testing.T) {
 	backend, _ := newTestBackend(t)
 	client, _ := backend.Attach()

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math/big"
 	"reflect"
 	"testing"
@@ -288,8 +289,8 @@ func TestHeader_TxesUnclesNotEmpty(t *testing.T) {
 
 	res := make(map[string]interface{})
 	err := client.CallContext(ctx, &res, "eth_getBlockByNumber", "latest", false)
-	if err == nil && res == nil {
-		err = ethereum.NotFound
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	// Sanity check response

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1216,8 +1216,8 @@ func (h *RPCMarshalHeaderT) setAsPending() {
 // RPCMarshalBlockT is a type handling RPC serialization for types.Block.
 type RPCMarshalBlockT struct {
 	*RPCMarshalHeaderT
-	Transactions []interface{} `json:"transactions,omitempty"`
-	Uncles       []common.Hash `json:"uncles,omitempty"`
+	Transactions []interface{} `json:"transactions"`
+	Uncles       []common.Hash `json:"uncles"`
 
 	Error string `json:"error,omitempty"`
 
@@ -1230,8 +1230,8 @@ type RPCMarshalBlockT struct {
 // RPCMarshalHeaderT is an embedded struct.
 type RPCMarshalBlockTIR struct {
 	*RPCMarshalHeaderT
-	Transactions []interface{} `json:"transactions,omitempty"`
-	Uncles       []common.Hash `json:"uncles,omitempty"`
+	Transactions []interface{} `json:"transactions"`
+	Uncles       []common.Hash `json:"uncles"`
 
 	Error string `json:"error,omitempty"`
 


### PR DESCRIPTION
This should return an empty array when empty.

Resolves https://github.com/etclabscore/core-geth/issues/332

Date: 2021-03-12 07:47:43-06:00
Signed-off-by: meows <b5c6@protonmail.com>