### PR TITLE
ci: comparative benchmarks for vm, core, and trie operations

### DIFF
--- a/.github/workflows/bench-core.yml
+++ b/.github/workflows/bench-core.yml
@@ -1,0 +1,96 @@
+name: Benchmark Core
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  bench_core_geth:
+    name: Benchmark core-geth
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Benchmark etclabscore/core-geth
+        id: bench
+        run: |
+          go test -short ./core -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee core-geth.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: core-geth
+          path: ./core-geth.txt
+
+  bench_go_ethereum:
+    name: Benchmark go-ethereum
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          repository: 'ethereum/go-ethereum'
+          ref: 'v1.9.25'
+
+      - name: Benchmark ethereum/go-ethereum
+        id: bench
+        run: |
+          go test -short ./core -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee go-ethereum.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: go-ethereum
+          path: ./go-ethereum.txt
+
+  compare:
+    name: Compare
+    needs: [bench_core_geth, bench_go_ethereum]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          cd ..
+          go get golang.org/x/perf/cmd/...
+          cd -
+
+      - uses: actions/download-artifact@v2
+        name: Get go-ethereum artifact
+        with:
+          name: go-ethereum
+
+      - uses: actions/download-artifact@v2
+        name: Get core-geth artifact
+        with:
+          name: core-geth
+
+      - name: "Analyze Results [COMPRESSED]"
+        run: |
+          benchstat --geomean go-ethereum.txt core-geth.txt
+
+      - name: "Analyze Results [RAW DELTA]"
+        run: |
+          benchstat --geomean --delta-test=none go-ethereum.txt core-geth.txt

--- a/.github/workflows/bench-trie.yml
+++ b/.github/workflows/bench-trie.yml
@@ -1,0 +1,96 @@
+name: Benchmark Trie
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  bench_core_geth:
+    name: Benchmark core-geth
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Benchmark etclabscore/core-geth
+        id: bench
+        run: |
+          go test -short ./trie -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee core-geth.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: core-geth
+          path: ./core-geth.txt
+
+  bench_go_ethereum:
+    name: Benchmark go-ethereum
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          repository: 'ethereum/go-ethereum'
+          ref: 'v1.9.25'
+
+      - name: Benchmark ethereum/go-ethereum
+        id: bench
+        run: |
+          go test -short ./trie -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee go-ethereum.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: go-ethereum
+          path: ./go-ethereum.txt
+
+  compare:
+    name: Compare
+    needs: [bench_core_geth, bench_go_ethereum]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          cd ..
+          go get golang.org/x/perf/cmd/...
+          cd -
+
+      - uses: actions/download-artifact@v2
+        name: Get go-ethereum artifact
+        with:
+          name: go-ethereum
+
+      - uses: actions/download-artifact@v2
+        name: Get core-geth artifact
+        with:
+          name: core-geth
+
+      - name: "Analyze Results [COMPRESSED]"
+        run: |
+          benchstat --geomean go-ethereum.txt core-geth.txt
+
+      - name: "Analyze Results [RAW DELTA]"
+        run: |
+          benchstat --geomean --delta-test=none go-ethereum.txt core-geth.txt

--- a/.github/workflows/bench-vm.yml
+++ b/.github/workflows/bench-vm.yml
@@ -1,0 +1,107 @@
+name: Benchmark VM
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  bench_core_geth:
+    name: Benchmark core-geth
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Benchmark etclabscore/core-geth
+        id: bench
+        run: |
+          go test -short ./tests -count 1 -p 1 -timeout 60m -run NONE -bench=VM -v |& tee core-geth.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: core-geth
+          path: ./core-geth.txt
+
+  bench_go_ethereum:
+    name: Benchmark go-ethereum
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Benchmark ethereum/go-ethereum
+        id: bench
+        run: |
+          git remote add foundation https://github.com/ethereum/go-ethereum.git
+          git fetch foundation
+          git checkout v1.9.25
+          # git submodule update
+          git checkout $GITHUB_SHA -- tests/vm_bench_test.go
+          go test -short ./tests -count 1 -p 1 -timeout 60m -run NONE -bench=VM -v |& tee go-ethereum.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: go-ethereum
+          path: ./go-ethereum.txt
+
+  compare:
+    name: Compare
+    needs: [bench_core_geth, bench_go_ethereum]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Set up Go 1.x
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          cd ..
+          go get golang.org/x/perf/cmd/...
+          cd -
+
+      - uses: actions/download-artifact@v2
+        name: Get go-ethereum artifact
+        with:
+          name: go-ethereum
+
+      - uses: actions/download-artifact@v2
+        name: Get core-geth artifact
+        with:
+          name: core-geth
+
+      - name: Prepare data
+        run: |
+          cat core-geth.txt | ./build/bench-suite-compress.sh | tee core-geth_compress.txt
+          cat go-ethereum.txt | ./build/bench-suite-compress.sh | tee go-ethereum_compress.txt
+
+      - name: "Analyze Results [COMPRESSED]"
+        run: |
+          benchstat --geomean go-ethereum_compress.txt core-geth_compress.txt
+
+      - name: "Analyze Results [RAW DELTA]"
+        run: |
+          benchstat --geomean --delta-test=none go-ethereum.txt core-geth.txt

--- a/build/bench-suite-compress.sh
+++ b/build/bench-suite-compress.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# suite_compressor is intended for use with the tests/ suite.
+# It strips the filename from a benchmark test result line.
+# This generalization causes the benchstat util to treat each file as a rerun of a single
+# test, which yields a more generalized statistic including almost believable p values.
+#
+# Eg.
+#
+# BenchmarkVM/vmArithmeticTest/addmod1_overflow2.json-12             35870             36298 ns/op                24.27 mgas/s       21434 B/op     311 allocs/op
+# BenchmarkVM/vmArithmeticTest/addmod1_overflow3.json-12             29626             37401 ns/op               102.9 mgas/s        22371 B/op     315 allocs/op
+# BenchmarkVM/vmArithmeticTest/addmod1_overflow4.json-12             30820             37519 ns/op               103.2 mgas/s        22382 B/op     315 allocs/op
+#
+# becomes:
+#
+# BenchmarkVM/vmArithmeticTest             35870             36298 ns/op                24.27 mgas/s       21434 B/op     311 allocs/op
+# BenchmarkVM/vmArithmeticTest             29626             37401 ns/op               102.9 mgas/s        22371 B/op     315 allocs/op
+# BenchmarkVM/vmArithmeticTest             30820             37519 ns/op               103.2 mgas/s        22382 B/op     315 allocs/op
+#
+while read -r line
+do
+    if grep -q '/op' <<< "$line"
+    then echo "$(dirname $(echo ${line} | cut -d' ' -f1)) $(echo $line | cut -d' ' -f2-)"
+    fi
+done

--- a/tests/vm_bench_test.go
+++ b/tests/vm_bench_test.go
@@ -1,0 +1,154 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+func BenchmarkVM(b *testing.B) {
+	vmt := new(testMatcher)
+	vmt.skipLoad("^vmSystemOperationsTest.json")
+	vmt.walkB(b, vmTestDir, func(b *testing.B, name string, test *VMTest) {
+		b.ReportAllocs()
+		vmconfig := vm.Config{EVMInterpreter: *testEVM, EWASMInterpreter: *testEWASM}
+		var statedb = &state.StateDB{}
+		_, sdb := MakePreState(rawdb.NewMemoryDatabase(), test.json.Pre, false)
+		*statedb = *sdb
+		start := time.Now()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			test.exec(statedb, vmconfig)
+			b.StopTimer()
+			*statedb = *sdb
+			b.StartTimer()
+		}
+		b.StopTimer()
+		gasRemaining := uint64(0)
+		if test.json.GasRemaining != nil {
+			gasRemaining = uint64(*test.json.GasRemaining)
+		}
+		gasUsed := test.json.Exec.GasLimit - gasRemaining
+		elapsed := uint64(time.Since(start))
+		if elapsed < 1 {
+			elapsed = 1
+		}
+		mgasps := (100 * 1000 * gasUsed * uint64(b.N)) / elapsed
+		b.ReportMetric(float64(mgasps)/100, "mgas/s")
+	})
+}
+
+// walk invokes its runTest argument for all subtests in the given directory.
+//
+// runTest should be a function of type func(t *testing.T, name string, x <TestType>),
+// where TestType is the type of the test contained in test files.
+func (tm *testMatcher) walkB(b *testing.B, dir string, runTest interface{}) {
+	// Walk the directory.
+	dirinfo, err := os.Stat(dir)
+	if os.IsNotExist(err) || !dirinfo.IsDir() {
+		fmt.Fprintf(os.Stderr, "can'b find test files in %s, did you clone the tests submodule?\n", dir)
+		b.Fatal("missing test files")
+	}
+	// shortSelectFiles is used as a lookup under the -short testing option
+	// to benchmark only the first of each species of test (instead of all iterations of each JSON VM test).
+	shortSelectFiles := make(map[string]bool)
+	shouldSkip := func(path string) bool {
+		if !testing.Short() {
+			return false
+		}
+		fname := strings.TrimSuffix(filepath.Base(path), ".json")
+		onlyWords := regexp.MustCompile(`^[a-zA-Z_]+`)
+		matches := onlyWords.FindStringSubmatch(fname)
+		match1 := fname
+		if len(matches) > 0 {
+			match1 = matches[0]
+		}
+		if _, ok := shortSelectFiles[match1]; ok {
+			return true
+		}
+		b.Logf("select test: %s", match1)
+		shortSelectFiles[match1] = true
+		return false
+	}
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		name := filepath.ToSlash(strings.TrimPrefix(path, dir+string(filepath.Separator)))
+		if info.IsDir() {
+			if _, skipload := tm.findSkip(name + "/"); skipload {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) == ".json" {
+			if shouldSkip(path) {
+				return nil
+			}
+			b.Run(name, func(b *testing.B) { tm.runTestFileB(b, path, name, runTest) })
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func (tm *testMatcher) runTestFileB(b *testing.B, path, name string, runTest interface{}) {
+	if r, _ := tm.findSkip(name); r != "" {
+		b.Skip(r)
+	}
+	if tm.whitelistpat != nil {
+		if !tm.whitelistpat.MatchString(name) {
+			b.Skip("Skipped by whitelist")
+		}
+	}
+
+	// Load the file as map[string]<testType>.
+	m := makeMapFromTestFuncB(runTest)
+	if err := readJSONFile(path, m.Addr().Interface()); err != nil {
+		b.Fatal(err)
+	}
+
+	// Run all tests from the map. Don't wrap in a subtest if there is only one test in the file.
+	keys := sortedMapKeys(m)
+	if len(keys) == 1 {
+		runTestFuncB(runTest, b, name, m, keys[0])
+	} else {
+		for _, key := range keys {
+			name := name + "/" + key
+			b.Run(key, func(b *testing.B) {
+				if r, _ := tm.findSkip(name); r != "" {
+					b.Skip(r)
+				}
+				runTestFuncB(runTest, b, name, m, key)
+			})
+		}
+	}
+}
+
+func makeMapFromTestFuncB(f interface{}) reflect.Value {
+	stringT := reflect.TypeOf("")
+	testingT := reflect.TypeOf((*testing.B)(nil))
+	ftyp := reflect.TypeOf(f)
+	if ftyp.Kind() != reflect.Func || ftyp.NumIn() != 3 || ftyp.NumOut() != 0 || ftyp.In(0) != testingT || ftyp.In(1) != stringT {
+		panic(fmt.Sprintf("bad test function type: want func(*testing.B, string, <TestType>), have %s", ftyp))
+	}
+	testType := ftyp.In(2)
+	mp := reflect.New(reflect.MapOf(stringT, testType))
+	return mp.Elem()
+}
+
+func runTestFuncB(runTest interface{}, b *testing.B, name string, m reflect.Value, key string) {
+	reflect.ValueOf(runTest).Call([]reflect.Value{
+		reflect.ValueOf(b),
+		reflect.ValueOf(name),
+		m.MapIndex(reflect.ValueOf(key)),
+	})
+}

--- a/tests/vm_bench_test.go
+++ b/tests/vm_bench_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
+// BenchmarkVM runs benchmarks against the JSON VM test suite cases.
+// If the go test -short flag is passed, only the FIRST file in each subdirectory
+// (which describes related groups of tests) will be run.
 func BenchmarkVM(b *testing.B) {
 	vmt := new(testMatcher)
 	vmt.skipLoad("^vmSystemOperationsTest.json")
@@ -47,7 +50,7 @@ func BenchmarkVM(b *testing.B) {
 	})
 }
 
-// walk invokes its runTest argument for all subtests in the given directory.
+// walkB invokes its runTest argument for all subtests in the given directory.
 //
 // runTest should be a function of type func(t *testing.T, name string, x <TestType>),
 // where TestType is the type of the test contained in test files.


### PR DESCRIPTION
Rel #283

Provides 
- new benchmarking functionality for the JSON VM tests suite (`tests/vm_bench_test.go`)
- 3 new Github Actions workflows that compare go-ethereum vs. core-geth benchmarks for
  + the JSON VM tests,
  + `core/`, and
  + `trie/` packages.

Intention is to provide a reliable means of establishing efficiency and optimization comparison with upstream source.
Example test runs can be seen on my personal fork at https://github.com/meowsbits/core-geth/actions. 

The actions' workflows run go-ethereum and core-geth jobs in parallel, and compare the results using `benchstat`.
