### PR TITLE
.github/workflows: fix not-gofmt'd bootnodes files after audit

### DIFF
--- a/.github/workflows/audit-bootnodes.yml
+++ b/.github/workflows/audit-bootnodes.yml
@@ -56,6 +56,7 @@ jobs:
               if [[ $GITHUB_EVENT_NAME != pull_request ]]; then
                 id="$(basename ${failed} | cut -d'@' -f1)"
                 sed -i '/'"${id}"'/d' "${file}"
+                gofmt -w "${file}"
               else
                 status=1
               fi


### PR DESCRIPTION
Date: 2021-03-15 07:15:26-05:00
Signed-off-by: meows <b5c6@protonmail.com>

Rel #339
Example failing lint step at CI: https://travis-ci.org/github/etclabscore/core-geth/builds/762920583