### PR TITLE
ethclient: fix missing doublequote in example

### DIFF
--- a/ethclient/docsgen_test.go
+++ b/ethclient/docsgen_test.go
@@ -145,7 +145,7 @@ func TestRPCDiscover_BuildStatic(t *testing.T) {
 				paramNames = strings.Join(out, ", ")
 			}
 
-			return fmt.Sprintf(`curl -X POST http://localhost:8545 --data '{"jsonrpc": "2.0", id": 42, "method": "%s", "params": [%s]}'`, *m.Name, paramNames)
+			return fmt.Sprintf(`curl -X POST http://localhost:8545 --data '{"jsonrpc": "2.0", "id": 42, "method": "%s", "params": [%s]}'`, *m.Name, paramNames)
 		},
 	})
 


### PR DESCRIPTION
Date: 2021-03-17 06:12:55-05:00
Signed-off-by: meows <b5c6@protonmail.com>