### PR TITLE
docs: Upgrade MkDocs requirements

### DIFF
--- a/requirements-mkdocs.txt
+++ b/requirements-mkdocs.txt
@@ -4,7 +4,7 @@ future==0.18.2
 gitdb==4.0.5
 GitPython==3.1.12
 htmlmin==0.1.12
-Jinja2==2.11.2
+Jinja2==2.11.3
 joblib==1.0.0
 jsmin==2.2.2
 livereload==2.6.3
@@ -13,7 +13,8 @@ Markdown==3.3.3
 MarkupSafe==1.1.1
 mkdocs==1.1.2
 mkdocs-git-revision-date-localized-plugin==0.8
-mkdocs-material==6.2.4
+mkdocs-macros-test==0.1.0
+mkdocs-material==7.0.6
 mkdocs-material-extensions==1.0.1
 mkdocs-minify-plugin==0.3.0
 nltk==3.5
@@ -21,7 +22,7 @@ Pygments==2.7.3
 pymdown-extensions==8.1
 python-dateutil==2.8.1
 pytz==2020.5
-PyYAML==5.3.1
+PyYAML>=5.4
 regex==2020.11.13
 six==1.15.0
 smmap==3.0.4


### PR DESCRIPTION
This PR triggered because of depend-a-bot request for potential risks in the packages `PyYAML` and `Jinja2`.