### PR TITLE
.travis.yml: fix typos in arm64 job go version (should be 1.16.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
   # These tests are divided in half because their aggregate typical runtime
   # exceeds Travis' time limit (~60m) and were consistently causing timeouts.
   - stage: build
-    name: "ARM64/Go1.15.x: make test [A-G]"
+    name: "ARM64/Go1.16.x: make test [A-G]"
     if: type = pull_request
     os: linux
     arch: arm64
@@ -52,12 +52,12 @@ jobs:
     script:
       - go run build/ci.go test -coverage $(printf './%s/... ' $(go list ./... | sed 's|github.com/ethereum/go-ethereum||g' | cut -d'/' -f2 | uniq | grep -E '^[a-g]'))
   - stage: build
-    name: "ARM64/Go1.15.x: make test [H-Z]"
+    name: "ARM64/Go1.16.x: make test [H-Z]"
     if: type = pull_request
     os: linux
     arch: arm64
     dist: xenial
-    go: 1.15.x
+    go: 1.16.x
     env:
       - GO111MODULE=on
     script:


### PR DESCRIPTION
Date: 2021-03-29 10:02:35-05:00
Signed-off-by: meows <b5c6@protonmail.com>