### PR TITLE
Set activation blocks for Magneto on classic|mordor|kotti chains

### DIFF
--- a/params/config_classic.go
+++ b/params/config_classic.go
@@ -72,6 +72,13 @@ var (
 		EIP2028FBlock: big.NewInt(10_500_839),
 		EIP2200FBlock: big.NewInt(10_500_839), // RePetersburg (=~ re-1283)
 
+		// Berlin eq, aka Magneto
+		EIP2315FBlock: big.NewInt(12_759_699),
+		EIP2565FBlock: big.NewInt(12_759_699),
+		EIP2718FBlock: big.NewInt(12_759_699),
+		EIP2929FBlock: big.NewInt(12_759_699),
+		EIP2930FBlock: big.NewInt(12_759_699),
+
 		ECIP1099FBlock: big.NewInt(11_700_000), // Etchash (DAG size limit)
 
 		DisposalBlock:      big.NewInt(5900000),
@@ -132,6 +139,13 @@ var (
 		EIP1884FBlock: big.NewInt(10),
 		EIP2028FBlock: big.NewInt(10),
 		EIP2200FBlock: big.NewInt(10), // RePetersburg (=~ re-1283)
+
+		// Berlin eq, aka Magneto
+		EIP2315FBlock: big.NewInt(11),
+		EIP2565FBlock: big.NewInt(11),
+		EIP2718FBlock: big.NewInt(11),
+		EIP2929FBlock: big.NewInt(11),
+		EIP2930FBlock: big.NewInt(11),
 
 		DisposalBlock:      big.NewInt(5),
 		ECIP1017FBlock:     big.NewInt(5),

--- a/params/config_kotti.go
+++ b/params/config_kotti.go
@@ -71,6 +71,13 @@ var (
 		EIP2028FBlock: big.NewInt(2_200_013),
 		EIP2200FBlock: big.NewInt(2_200_013), // RePetersburg (== re-1283)
 
+		// Berlin eq, aka Magneto
+		EIP2315FBlock: big.NewInt(4_110_482),
+		EIP2565FBlock: big.NewInt(4_110_482),
+		EIP2718FBlock: big.NewInt(4_110_482),
+		EIP2929FBlock: big.NewInt(4_110_482),
+		EIP2930FBlock: big.NewInt(4_110_482),
+
 		RequireBlockHashes: map[uint64]common.Hash{
 			0: KottiGenesisHash,
 			/*

--- a/params/config_mordor.go
+++ b/params/config_mordor.go
@@ -66,6 +66,13 @@ var (
 		EIP2028FBlock: big.NewInt(999_983),
 		EIP2200FBlock: big.NewInt(999_983), // RePetersburg (== re-1283)
 
+		// Berlin eq, aka Magneto
+		EIP2315FBlock: big.NewInt(3_585_073),
+		EIP2565FBlock: big.NewInt(3_585_073),
+		EIP2718FBlock: big.NewInt(3_585_073),
+		EIP2929FBlock: big.NewInt(3_585_073),
+		EIP2930FBlock: big.NewInt(3_585_073),
+
 		ECIP1099FBlock: big.NewInt(2_520_000), // Etchash
 
 		DisposalBlock:      big.NewInt(0),


### PR DESCRIPTION
The ECIP https://github.com/ethereumclassic/ECIPs/pull/411 is still in draft mode. So I opened this PR with `A3-inprogress` label assigned.

It's complimentary to #365. 