### PR TITLE
Fix allowing of selecting protocol versions after merge of 1.10.x

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -155,7 +155,7 @@ var (
 	}
 	EthProtocolsFlag = cli.StringFlag{
 		Name:  "eth.protocols",
-		Usage: "Sets the Ethereum Protocol versions (65|64|63) (default = 65,64,63 first is primary)",
+		Usage: "Sets the Ethereum Protocol versions (66|65|64) (default = 66,65,64 first is primary)",
 		Value: "",
 	}
 	ClassicFlag = cli.BoolFlag{
@@ -1731,7 +1731,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.GlobalIsSet(EthProtocolsFlag.Name) {
 		protocolVersions := SplitAndTrim(ctx.GlobalString(EthProtocolsFlag.Name))
 		if len(protocolVersions) == 0 {
-			Fatalf("--%s must be comma separated list of %s", EthProtocolsFlag.Name, strings.Join(strings.Fields(fmt.Sprint(ethconfig.Defaults.ProtocolVersions)), ","))
+			Fatalf("--%s must be comma separated list of %s", EthProtocolsFlag.Name, strings.Join(strings.Fields(fmt.Sprint(eth.DefaultProtocolVersions)), ","))
 		}
 
 		seenVersions := map[uint]interface{}{}
@@ -1746,7 +1746,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			}
 
 			isValid := false
-			for _, proto := range ethconfig.Defaults.ProtocolVersions {
+			for _, proto := range eth.DefaultProtocolVersions {
 				if proto == uint(version) {
 					isValid = true
 					seenVersions[uint(version)] = nil
@@ -1755,7 +1755,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			}
 
 			if !isValid {
-				Fatalf("--%s must be comma separated list of %s", EthProtocolsFlag.Name, strings.Join(strings.Fields(fmt.Sprint(ethconfig.Defaults.ProtocolVersions)), ","))
+				Fatalf("--%s must be comma separated list of %s", EthProtocolsFlag.Name, strings.Join(strings.Fields(fmt.Sprint(eth.DefaultProtocolVersions)), ","))
 			}
 			cfg.ProtocolVersions = append(cfg.ProtocolVersions, uint(version))
 		}
@@ -1763,7 +1763,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 
 	// set default protocol versions
 	if len(cfg.ProtocolVersions) == 0 {
-		cfg.ProtocolVersions = ethconfig.Defaults.ProtocolVersions
+		cfg.ProtocolVersions = eth.DefaultProtocolVersions
 	}
 
 	// Set DNS discovery defaults for hard coded networks with DNS defaults.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -172,7 +172,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if bcVersion != nil {
 		dbVer = fmt.Sprintf("%d", *bcVersion)
 	}
-	log.Info("Initialising Ethereum protocol", "versions", config.ProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
+	log.Info("Initialising Ethereum protocol", "network", config.NetworkId, "dbversion", dbVer)
 
 	if !config.SkipBcVersionCheck {
 		if bcVersion != nil && *bcVersion > core.BlockChainVersion {
@@ -532,7 +532,7 @@ func (s *Ethereum) Engine() consensus.Engine          { return s.engine }
 func (s *Ethereum) ChainDb() ethdb.Database           { return s.chainDb }
 func (s *Ethereum) IsListening() bool                 { return true } // Always listening
 func (s *Ethereum) EthVersion() int {
-	return int(eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.ethDialCandidates)[0].Version)
+	return int(eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.config.ProtocolVersions, s.ethDialCandidates)[0].Version)
 }
 func (s *Ethereum) NetVersion() uint64                 { return s.networkID }
 func (s *Ethereum) Downloader() *downloader.Downloader { return s.handler.downloader }
@@ -543,7 +543,7 @@ func (s *Ethereum) BloomIndexer() *core.ChainIndexer   { return s.bloomIndexer }
 // Protocols returns all the currently configured
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
-	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.ethDialCandidates)
+	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.config.ProtocolVersions, s.ethDialCandidates)
 	if s.config.SnapshotCache > 0 {
 		protos = append(protos, snap.MakeProtocols((*snapHandler)(s.handler), s.snapDialCandidates)...)
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -51,6 +51,10 @@ var (
 	syncChallengeTimeout = 15 * time.Second // Time allowance for a node to reply to the sync progress challenge
 )
 
+// DefaultProtocolVersions are the supported versions of the `eth` protocol (first
+// is primary).
+var DefaultProtocolVersions = []uint{eth.ETH66, eth.ETH65, eth.ETH64}
+
 // txPool defines the methods needed from a transaction pool implementation to
 // support all the operations needed by the Ethereum chain protocols.
 type txPool interface {

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -101,9 +101,9 @@ type TxPool interface {
 }
 
 // MakeProtocols constructs the P2P protocol definitions for `eth`.
-func MakeProtocols(backend Backend, network uint64, dnsdisc enode.Iterator) []p2p.Protocol {
-	protocols := make([]p2p.Protocol, len(ProtocolVersions))
-	for i, version := range ProtocolVersions {
+func MakeProtocols(backend Backend, network uint64, protocolVersions []uint, dnsdisc enode.Iterator) []p2p.Protocol {
+	protocols := make([]p2p.Protocol, len(protocolVersions))
+	for i, version := range protocolVersions {
 		version := version // Closure
 
 		protocols[i] = p2p.Protocol{


### PR DESCRIPTION
Keep in mind that Eth protocol version 63 has been dropped.
_EDIT(meowsbits) (And 62 was dropped a long time ago.)_

Ref #365