### PR TITLE
cmd/geth,internal/cmdtest: add KillTimeout field to TestCmd struct

### DIFF
--- a/cmd/geth/consolecmd_cg_test.go
+++ b/cmd/geth/consolecmd_cg_test.go
@@ -160,6 +160,7 @@ func TestGethStartupLogs(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("TestGethStartupLogs/%d: %v", i, c.flags), func(t *testing.T) {
 			geth := runGeth(t, append(c.flags, "--exec", "admin.nodeInfo.name", "console")...)
+			geth.KillTimeout = 10 * time.Second
 			geth.ExpectRegexp("(?ism).*CoreGeth.*")
 			geth.ExpectExit()
 			if status := geth.ExitStatus(); status != 0 {

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -37,16 +37,17 @@ import (
 )
 
 func NewTestCmd(t *testing.T, data interface{}) *TestCmd {
-	return &TestCmd{T: t, Data: data}
+	return &TestCmd{T: t, Data: data, KillTimeout: 5 * time.Second}
 }
 
 type TestCmd struct {
 	// For total convenience, all testing methods are available.
 	*testing.T
 
-	Func    template.FuncMap
-	Data    interface{}
-	Cleanup func()
+	Func        template.FuncMap
+	Data        interface{}
+	Cleanup     func()
+	KillTimeout time.Duration
 
 	cmd    *exec.Cmd
 	stdout *bufio.Reader
@@ -231,7 +232,7 @@ func (tt *TestCmd) Kill() {
 }
 
 func (tt *TestCmd) withKillTimeout(fn func()) {
-	timeout := time.AfterFunc(5*time.Second, func() {
+	timeout := time.AfterFunc(tt.KillTimeout, func() {
 		tt.Log("killing the child process (timeout)")
 		tt.Kill()
 	})


### PR DESCRIPTION
TestGethStartupLogs was failing because of shutdown
timeout, via https://travis-ci.org/github/etclabscore/core-geth/jobs/770485427.

This allows a configurable process kill timeout window
and provides an unchanged default (5 seconds).

Note that the field isn't protected or really closely
integrated with the process runner at (ie via runGeth function),
so the kill field basically just gets set on the fly and
hopes that it gets set before the shutdown logic is called.

Date: 2021-05-11 05:56:29-05:00
Signed-off-by: meows <b5c6@protonmail.com>