### PR TITLE
cmd/utils: set default for --eth.protocols flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1771,11 +1771,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 	}
 
-	// set default protocol versions
-	if len(cfg.ProtocolVersions) == 0 {
-		cfg.ProtocolVersions = eth.DefaultProtocolVersions
-	}
-
 	// Set DNS discovery defaults for hard coded networks with DNS defaults.
 	switch {
 	case ctx.GlobalBool(MainnetFlag.Name):

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -156,7 +156,12 @@ var (
 	EthProtocolsFlag = cli.StringFlag{
 		Name:  "eth.protocols",
 		Usage: "Sets the Ethereum Protocol versions (66|65|64) (default = 66,65,64 first is primary)",
-		Value: "",
+		Value: strings.Join(func() (strings []string) {
+			for _, s := range eth.DefaultProtocolVersions {
+				strings = append(strings, strconv.Itoa(int(s)))
+			}
+			return
+		}(), ","),
 	}
 	ClassicFlag = cli.BoolFlag{
 		Name:  "classic",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -155,7 +155,7 @@ var (
 	}
 	EthProtocolsFlag = cli.StringFlag{
 		Name:  "eth.protocols",
-		Usage: "Sets the Ethereum Protocol versions (66|65|64) (default = 66,65,64 first is primary)",
+		Usage: "Sets the Ethereum Protocol versions (first is primary)",
 		Value: strings.Join(func() (strings []string) {
 			for _, s := range eth.DefaultProtocolVersions {
 				strings = append(strings, strconv.Itoa(int(s)))


### PR DESCRIPTION
The default is assigned to the config later if `len(config.protocols) == 0`, so this should not change any effect; but intention is to provide a more user-facing and consistent experience.