### PR TITLE
p2p/nat: skip TestUPNP in non-CI envs if discover fails

### DIFF
--- a/p2p/nat/natupnp_test.go
+++ b/p2p/nat/natupnp_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -162,7 +163,11 @@ func TestUPNP_DDWRT(t *testing.T) {
 	// Attempt to discover the fake device.
 	discovered := discoverUPnP()
 	if discovered == nil {
-		t.Fatalf("not discovered")
+		if os.Getenv("CI") != "" {
+			t.Fatalf("not discovered")
+		} else {
+			t.Skipf("UPnP not discovered (known issue, see https://github.com/ethereum/go-ethereum/issues/21476)")
+		}
 	}
 
 	upnp, _ := discovered.(*upnp)


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/issues/21476

Date: 2021-05-13 12:33:01-05:00
Signed-off-by: meows <b5c6@protonmail.com>