### PR TITLE
Set activation blocks for Magneto on classic|mordor|kotti chains

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -172,8 +172,11 @@ func TestCreation(t *testing.T) {
 				{10500839, ID{Hash: checksumToBytes(0x9007bfcc), Next: 11_700_000}},
 				{10500840, ID{Hash: checksumToBytes(0x9007bfcc), Next: 11_700_000}},
 				{11_699_999, ID{Hash: checksumToBytes(0x9007bfcc), Next: 11_700_000}},
-				{11_700_000, ID{Hash: checksumToBytes(0xdb63a1ca), Next: 0}},
-				{11_700_001, ID{Hash: checksumToBytes(0xdb63a1ca), Next: 0}},
+				{11_700_000, ID{Hash: checksumToBytes(0xdb63a1ca), Next: 13_189_133}},
+				{11_700_001, ID{Hash: checksumToBytes(0xdb63a1ca), Next: 13_189_133}},
+				{13_189_132, ID{Hash: checksumToBytes(0xdb63a1ca), Next: 13_189_133}},
+				{13_189_133, ID{Hash: checksumToBytes(0x0f6bf187), Next: 0}},
+				{13_189_134, ID{Hash: checksumToBytes(0x0f6bf187), Next: 0}},
 			},
 		},
 		{
@@ -189,8 +192,11 @@ func TestCreation(t *testing.T) {
 				{1705549, ID{Hash: checksumToBytes(0x8f3698e0), Next: 2200013}},
 				{1705550, ID{Hash: checksumToBytes(0x8f3698e0), Next: 2200013}},
 				{2200012, ID{Hash: checksumToBytes(0x8f3698e0), Next: 2200013}},
-				{2200013, ID{Hash: checksumToBytes(0x6f402821), Next: 0}},
-				{2200014, ID{Hash: checksumToBytes(0x6f402821), Next: 0}},
+				{2200013, ID{Hash: checksumToBytes(0x6f402821), Next: 4_368_634}},
+				{2200014, ID{Hash: checksumToBytes(0x6f402821), Next: 4_368_634}},
+				{4_368_633, ID{Hash: checksumToBytes(0x6f402821), Next: 4_368_634}},
+				{4_368_634, ID{Hash: checksumToBytes(0xf03e54e7), Next: 0}},
+				{4_368_635, ID{Hash: checksumToBytes(0xf03e54e7), Next: 0}},
 			},
 		},
 		{
@@ -211,14 +217,17 @@ func TestCreation(t *testing.T) {
 				{999983, ID{Hash: checksumToBytes(0xf42f5539), Next: 2_520_000}},
 				{999984, ID{Hash: checksumToBytes(0xf42f5539), Next: 2_520_000}},
 				{2_519_999, ID{Hash: checksumToBytes(0xf42f5539), Next: 2_520_000}},
-				{2_520_000, ID{Hash: checksumToBytes(0x66b5c286), Next: 0}},
+				{2_520_000, ID{Hash: checksumToBytes(0x66b5c286), Next: 3_985_893}},
+				{3_985_892, ID{Hash: checksumToBytes(0x66b5c286), Next: 3_985_893}},
+				{3_985_893, ID{Hash: checksumToBytes(0x92b323e0), Next: 0}},
+				{3_985_894, ID{Hash: checksumToBytes(0x92b323e0), Next: 0}},
 			},
 		},
 	}
 	for i, tt := range tests {
 		for j, ttt := range tt.cases {
 			if have := NewID(tt.config, tt.genesis, ttt.head); have != ttt.want {
-				t.Errorf("test %d, case %d: fork ID mismatch: have %x, want %x", i, j, have, ttt.want)
+				t.Errorf("chain: %s, test %d, case %d: fork ID mismatch: have %x, want %x", tt.name, i, j, have, ttt.want)
 			}
 		}
 	}
@@ -334,7 +343,7 @@ func TestGatherForks(t *testing.T) {
 		{
 			"classic",
 			params.ClassicChainConfig,
-			[]uint64{1150000, 2500000, 3000000, 5000000, 5900000, 8772000, 9573000, 10500839, 11_700_000},
+			[]uint64{1150000, 2500000, 3000000, 5000000, 5900000, 8772000, 9573000, 10500839, 11_700_000, 13_189_133},
 		},
 		{
 			"mainnet",
@@ -344,12 +353,12 @@ func TestGatherForks(t *testing.T) {
 		{
 			"mordor",
 			params.MordorChainConfig,
-			[]uint64{301_243, 999_983, 2_520_000},
+			[]uint64{301_243, 999_983, 2_520_000, 3_985_893},
 		},
 		{
 			"kotti",
 			params.KottiChainConfig,
-			[]uint64{716_617, 1_705_549, 2_200_013},
+			[]uint64{716_617, 1_705_549, 2_200_013, 4_368_634},
 		},
 	}
 	sliceContains := func(sl []uint64, u uint64) bool {

--- a/params/config_classic.go
+++ b/params/config_classic.go
@@ -74,6 +74,12 @@ var (
 		EIP2028FBlock: big.NewInt(10_500_839),
 		EIP2200FBlock: big.NewInt(10_500_839), // RePetersburg (=~ re-1283)
 
+		// Berlin eq, aka Magneto
+		EIP2565FBlock: big.NewInt(13_189_133),
+		EIP2718FBlock: big.NewInt(13_189_133),
+		EIP2929FBlock: big.NewInt(13_189_133),
+		EIP2930FBlock: big.NewInt(13_189_133),
+
 		ECIP1099FBlock: big.NewInt(11_700_000), // Etchash (DAG size limit)
 
 		DisposalBlock:      big.NewInt(5900000),
@@ -135,6 +141,12 @@ var (
 		EIP1884FBlock: big.NewInt(10),
 		EIP2028FBlock: big.NewInt(10),
 		EIP2200FBlock: big.NewInt(10), // RePetersburg (=~ re-1283)
+
+		// Berlin eq, aka Magneto
+		EIP2565FBlock: big.NewInt(11),
+		EIP2718FBlock: big.NewInt(11),
+		EIP2929FBlock: big.NewInt(11),
+		EIP2930FBlock: big.NewInt(11),
 
 		DisposalBlock:      big.NewInt(5),
 		ECIP1017FBlock:     big.NewInt(5),

--- a/params/config_kotti.go
+++ b/params/config_kotti.go
@@ -73,6 +73,12 @@ var (
 		EIP2028FBlock: big.NewInt(2_200_013),
 		EIP2200FBlock: big.NewInt(2_200_013), // RePetersburg (== re-1283)
 
+		// Berlin eq, aka Magneto
+		EIP2565FBlock: big.NewInt(4_368_634),
+		EIP2718FBlock: big.NewInt(4_368_634),
+		EIP2929FBlock: big.NewInt(4_368_634),
+		EIP2930FBlock: big.NewInt(4_368_634),
+
 		RequireBlockHashes: map[uint64]common.Hash{
 			0: KottiGenesisHash,
 			/*

--- a/params/config_mordor.go
+++ b/params/config_mordor.go
@@ -68,6 +68,12 @@ var (
 		EIP2028FBlock: big.NewInt(999_983),
 		EIP2200FBlock: big.NewInt(999_983), // RePetersburg (== re-1283)
 
+		// Berlin eq, aka Magneto
+		EIP2565FBlock: big.NewInt(3_985_893),
+		EIP2718FBlock: big.NewInt(3_985_893),
+		EIP2929FBlock: big.NewInt(3_985_893),
+		EIP2930FBlock: big.NewInt(3_985_893),
+
 		ECIP1099FBlock: big.NewInt(2_520_000), // Etchash
 
 		DisposalBlock:      big.NewInt(0),


### PR DESCRIPTION
The the activation numbers for Magneto based on the Dev's call outcome at https://github.com/ethereumclassic/ECIPs/issues/424

It's complimentary to #365.
Replaces #368.