### PR TITLE
cmd/faucet: skip Facebook test on Travis CI

### DIFF
--- a/cmd/faucet/faucet_test.go
+++ b/cmd/faucet/faucet_test.go
@@ -48,6 +48,8 @@ func TestMigrateFaucetDirectory(t *testing.T) {
 }
 
 func TestFacebook(t *testing.T) {
+	// TODO: Remove facebook auth or implement facebook api, which seems to require an API key
+	t.Skipf("The facebook access is flaky, needs to be reimplemented or removed")
 	for _, tt := range []struct {
 		url  string
 		want common.Address


### PR DESCRIPTION
Fixes #391.

The `res.StatusCode == 200`. I logged the `res.Body` Travis receives; unlike my local environment (which receives the proper page with post content), Travis receives a page indicating that authorization (log in) is required. I don't know why.

As an alternative to `t.Skip`, I would be open to removing the test altogether because I think that requiring internet access and making a live request to Facebook as a demand on the tests suite is a bad idea. (For example, could non-VPN/proxy users in China pass this test?)