### PR TITLE
cmd/utils: add default snap discovery to config during setup

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1866,6 +1866,7 @@ func SetDNSDiscoveryDefaults2(cfg *ethconfig.Config, url string) {
 		url = strings.Replace(url, "@all.", "@les.", 1)
 	}
 	cfg.EthDiscoveryURLs = []string{url}
+	cfg.SnapDiscoveryURLs = cfg.EthDiscoveryURLs
 }
 
 // SetDNSDiscoveryDefaults configures DNS discovery with the given URL if


### PR DESCRIPTION
This is behavior established at ethereum/go-ethereum for
now, though the snap-specific protocol DNS registrations
are disused; assumes coexistance of eth and snap protos.

Date: 2021-06-07 14:11:47-05:00
Signed-off-by: meows <b5c6@protonmail.com>