### PR TITLE
Feat/peer info forkid

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -63,7 +63,7 @@ func (p *ethPeer) info() *ethPeerInfo {
 	if p.Version() >= 64 {
 		info.ForkID = ethPeerInfoForkID{
 			Next: p.ForkID().Next,
-			Hash: fmt.Sprintf("%x", p.ForkID().Hash),
+			Hash: fmt.Sprintf("0x%x", p.ForkID().Hash),
 		}
 	}
 	return info

--- a/eth/protocols/eth/handshake.go
+++ b/eth/protocols/eth/handshake.go
@@ -65,7 +65,7 @@ func (p *Peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 			return p2p.DiscReadTimeout
 		}
 	}
-	p.td, p.head = status.TD, status.Head
+	p.td, p.head, p.forkid = status.TD, status.Head, status.ForkID
 
 	// TD at mainnet block #7753254 is 76 bits. If it becomes 100 million times
 	// larger, it will still fit within 100 bits

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -23,6 +23,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -72,8 +73,9 @@ type Peer struct {
 	rw        p2p.MsgReadWriter // Input/output streams for snap
 	version   uint              // Protocol version negotiated
 
-	head common.Hash // Latest advertised head block hash
-	td   *big.Int    // Latest advertised head block total difficulty
+	head   common.Hash // Latest advertised head block hash
+	td     *big.Int    // Latest advertised head block total difficulty
+	forkid forkid.ID   // Advertised forkid at time of handshake
 
 	knownBlocks     mapset.Set             // Set of block hashes known to be known by this peer
 	queuedBlocks    chan *blockPropagation // Queue of blocks to broadcast to the peer
@@ -147,6 +149,11 @@ func (p *Peer) SetHead(hash common.Hash, td *big.Int) {
 
 	copy(p.head[:], hash[:])
 	p.td.Set(td)
+}
+
+// ForkID retrieves the reported forkid at the time of handshake.
+func (p *Peer) ForkID() forkid.ID {
+	return p.forkid
 }
 
 // KnownBlock returns whether peer is known to already have a block.


### PR DESCRIPTION
Installs a `forkId` value returned under `PeerInfo` via the `admin` API (ie. `admin_peers`).

The `forkId` value is only included when the peer has an eth protocol version of eth/64 or greater.

eg.


```json
{
  "enr": "enr:-J24QaWZmRB53gMDDrpTINl-3SMWtaPY-X0WFPgg2mDNtyAeVAgJlZg15PfpyaxaiAg6I2jW678ADXDKv0JHV5Z57lQKg2V0aMfGhPA-VOeAgmlkgnY0gmlwhDMPKROJc2VjcDI1NmsxoQOTsSODx0w5tnr6maf_RM4lD-lClfofwIdGXMT-LQszuYRzbmFwwIN0Y3CCdl-DdWRwgnZf", 
  "enode": "enode://9cb12383c74c39b67afa99a7ff44ce250fe94295fa1fc087465cc4fe2d0b33b91a8d8cabe03b250104a9096aa0e06bcde5f95665a5bd9f890edd2ab33e16ae47@55.15.41.19:30303", 
  "id": "f8e8f899c0e6e08ed1580fba2f36c658af44f7a2823dcc520bd17a38cc24fdcf", 
  "name": "CoreGeth/v1.12.0-rc2/linux-amd64/go1.16.4", 
  "caps": ["eth/65", "eth/66", "snap/1"], 
  "network": {
    "localAddress": "11.19.0.26:37522", 
    "remoteAddress": "55.15.41.19:30303", 
    "inbound": false, 
    "trusted": false, 
    "static": false
  }, 
  "protocols": {
    "eth": {
      "version": 66, 
      "difficulty": 6533294, 
      "head": "0x9cf875a63ecef682f08c9b3a6d56b045cb5a42e5c74ec224fc34dd1d6fb21d25", 
      "forkId": {
        "next": 0, 
        "hash": "f03e54e7"
      }
    }, 
    "snap": {
      "version": 1
    }
  }
}
```