### PR TITLE
Allow using --gcmode=archive and --txlookuplimit=0 flags

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1591,8 +1591,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	CheckExclusive(ctx, DeveloperFlag, DeveloperPoWFlag, MainnetFlag, RopstenFlag, RinkebyFlag, GoerliFlag, YoloV3Flag, ClassicFlag, KottiFlag, MordorFlag, MintMeFlag)
 	CheckExclusive(ctx, LightServeFlag, SyncModeFlag, "light")
 	CheckExclusive(ctx, DeveloperFlag, DeveloperPoWFlag, ExternalSignerFlag) // Can't use both ephemeral unlocked and external signer
-	CheckExclusive(ctx, GCModeFlag, "archive", TxLookupLimitFlag)
 	if ctx.GlobalString(GCModeFlag.Name) == "archive" && ctx.GlobalUint64(TxLookupLimitFlag.Name) != 0 {
+		CheckExclusive(ctx, GCModeFlag, "archive", TxLookupLimitFlag)
 		ctx.GlobalSet(TxLookupLimitFlag.Name, "0")
 		log.Warn("Disable transaction unindexing for archive node")
 	}


### PR DESCRIPTION
When running with --gcmode=archive, it automatically sets --txlookuplimit=0, but if you explicitly set --txlookuplimit=0 it raises an exclusivity exception.

This change will only raise the exclusivity exception if --gcmode=archive is set and --txlookuplimit is explicitly set to something other than zero, allowing both flags to be set consistently with other Geth derivatives.

This is especially useful to us at Rivet so we don't have to have special rules for ETC to exclude the --txlookuplimit flag (or, as has historically been the case, a fork with this check commented out).