### PR TITLE
Introduce MintMe hardfork to avoid contract address collisions

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -187,7 +187,11 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig ctypes.ChainConfigura
 
 			// If the transaction created a contract, store the creation address in the receipt.
 			if msg.To() == nil {
-				receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+				if chainConfig.IsEnabled(chainConfig.GetLyra2NonceTransition, vmContext.BlockNumber) {
+					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce()+0x00ffffff)
+				} else {
+					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+				}
 			}
 
 			// Set the receipt logs and create the bloom filter.

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -35,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/params/mutations"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/genesisT"
+	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"golang.org/x/crypto/sha3"
@@ -189,7 +189,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig ctypes.ChainConfigura
 			// If the transaction created a contract, store the creation address in the receipt.
 			if msg.To() == nil {
 				if chainConfig.IsEnabled(chainConfig.GetLyra2NonceTransition, vmContext.BlockNumber) {
-					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce() + lyra2.ContractNonceOffset)
+					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce()+vars.Lyra2ContractNonceOffset)
 				} else {
 					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 				}

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -188,7 +189,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig ctypes.ChainConfigura
 			// If the transaction created a contract, store the creation address in the receipt.
 			if msg.To() == nil {
 				if chainConfig.IsEnabled(chainConfig.GetLyra2NonceTransition, vmContext.BlockNumber) {
-					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce()+0x00ffffff)
+					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce() + lyra2.ContractNonceOffset)
 				} else {
 					receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 				}

--- a/consensus/lyra2/consensus.go
+++ b/consensus/lyra2/consensus.go
@@ -29,8 +29,6 @@ var (
 	big32                    = big.NewInt(32)
 	DisinflationRateQuotient = big.NewInt(249)
 	DisinflationRateDivisor  = big.NewInt(250)
-
-	ContractNonceOffset uint64 = 0x00ffffff
 )
 
 // Various error messages to mark blocks invalid. These should be private to

--- a/consensus/lyra2/consensus.go
+++ b/consensus/lyra2/consensus.go
@@ -29,6 +29,8 @@ var (
 	big32                    = big.NewInt(32)
 	DisinflationRateQuotient = big.NewInt(249)
 	DisinflationRateDivisor  = big.NewInt(250)
+
+	ContractNonceOffset uint64 = 0x00ffffff
 )
 
 // Various error messages to mark blocks invalid. These should be private to

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -229,7 +229,8 @@ func TestCreation(t *testing.T) {
 			params.MintMeChainConfig,
 			params.MintMeGenesisHash,
 			[]testcase{
-				{0, ID{Hash: checksumToBytes(0x02bf4180), Next: 0}},
+				{0, ID{Hash: checksumToBytes(0x02bf4180), Next: 252500}},
+				{252500, ID{Hash: checksumToBytes(0x50aed09f), Next: 0}},
 			},
 		},
 	}
@@ -372,7 +373,7 @@ func TestGatherForks(t *testing.T) {
 		{
 			"mintme",
 			params.MintMeChainConfig,
-			[]uint64{},
+			[]uint64{252_500},
 		},
 	}
 	sliceContains := func(sl []uint64, u uint64) bool {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
-	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params/mutations"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
+	"github.com/ethereum/go-ethereum/params/vars"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -128,7 +128,7 @@ func applyTransaction(msg types.Message, config ctypes.ChainConfigurator, bc Cha
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To() == nil {
 		if config.IsEnabled(config.GetLyra2NonceTransition, header.Number) {
-			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce() + lyra2.ContractNonceOffset)
+			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce()+vars.Lyra2ContractNonceOffset)
 		} else {
 			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -127,7 +128,7 @@ func applyTransaction(msg types.Message, config ctypes.ChainConfigurator, bc Cha
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To() == nil {
 		if config.IsEnabled(config.GetLyra2NonceTransition, header.Number) {
-			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce()+0x00ffffff)
+			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce() + lyra2.ContractNonceOffset)
 		} else {
 			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -126,7 +126,11 @@ func applyTransaction(msg types.Message, config ctypes.ChainConfigurator, bc Cha
 
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To() == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+		if config.IsEnabled(config.GetLyra2NonceTransition, header.Number) {
+			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce()+0x00ffffff)
+		} else {
+			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+		}
 	}
 
 	// Set the receipt logs and create the bloom filter.

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -376,7 +376,11 @@ func (r Receipts) DeriveFields(config ctypes.ChainConfigurator, hash common.Hash
 		if txs[i].To() == nil {
 			// Deriving the signer is expensive, only do if it's actually needed
 			from, _ := Sender(signer, txs[i])
-			r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
+			if config.IsEnabled(config.GetLyra2NonceTransition, r[i].BlockNumber) {
+				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce()+0x00ffffff)
+			} else {
+				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
+			}
 		}
 		// The used gas can be calculated based on previous r
 		if i == 0 {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -377,7 +378,7 @@ func (r Receipts) DeriveFields(config ctypes.ChainConfigurator, hash common.Hash
 			// Deriving the signer is expensive, only do if it's actually needed
 			from, _ := Sender(signer, txs[i])
 			if config.IsEnabled(config.GetLyra2NonceTransition, r[i].BlockNumber) {
-				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce()+0x00ffffff)
+				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce() + lyra2.ContractNonceOffset)
 			} else {
 				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
 			}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
+	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -378,7 +378,7 @@ func (r Receipts) DeriveFields(config ctypes.ChainConfigurator, hash common.Hash
 			// Deriving the signer is expensive, only do if it's actually needed
 			from, _ := Sender(signer, txs[i])
 			if config.IsEnabled(config.GetLyra2NonceTransition, r[i].BlockNumber) {
-				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce() + lyra2.ContractNonceOffset)
+				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce()+vars.Lyra2ContractNonceOffset)
 			} else {
 				r[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
 			}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/ethereum/evmc/v7/bindings/go/evmc"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
@@ -500,7 +499,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	if evm.ChainConfig().IsEnabled(evm.ChainConfig().GetLyra2NonceTransition, evm.Context.BlockNumber) {
-		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()) + lyra2.ContractNonceOffset)
+		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address())+vars.Lyra2ContractNonceOffset)
 	} else {
 		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -498,7 +498,11 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
-	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
+	if evm.ChainConfig().IsEnabled(evm.ChainConfig().GetLyra2NonceTransition, evm.Context.BlockNumber) {
+		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address())+0x00ffffff)
+	} else {
+		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
+	}
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr)
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/evmc/v7/bindings/go/evmc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
@@ -499,7 +500,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	if evm.ChainConfig().IsEnabled(evm.ChainConfig().GetLyra2NonceTransition, evm.Context.BlockNumber) {
-		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address())+0x00ffffff)
+		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()) + lyra2.ContractNonceOffset)
 	} else {
 		contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1491,7 +1491,11 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	if args.To != nil {
 		to = *args.To
 	} else {
-		to = crypto.CreateAddress(args.From, uint64(*args.Nonce))
+		if b.ChainConfig().IsEnabled(b.ChainConfig().GetLyra2NonceTransition, header.Number) {
+			to = crypto.CreateAddress(args.From, uint64(*args.Nonce)+0x00ffffff)
+		} else {
+			to = crypto.CreateAddress(args.From, uint64(*args.Nonce))
+		}
 	}
 	var input []byte
 	if args.Input != nil {
@@ -1871,6 +1875,9 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 
 	if tx.To() == nil {
 		addr := crypto.CreateAddress(from, tx.Nonce())
+		if b.ChainConfig().IsEnabled(b.ChainConfig().GetLyra2NonceTransition, b.CurrentBlock().Number()) {
+			addr = crypto.CreateAddress(from, tx.Nonce()+0x00ffffff)
+		}
 		log.Info("Submitted contract creation", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "contract", addr.Hex(), "value", tx.Value())
 	} else {
 		log.Info("Submitted transaction", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "recipient", tx.To(), "value", tx.Value())

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -1492,7 +1493,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		to = *args.To
 	} else {
 		if b.ChainConfig().IsEnabled(b.ChainConfig().GetLyra2NonceTransition, header.Number) {
-			to = crypto.CreateAddress(args.From, uint64(*args.Nonce)+0x00ffffff)
+			to = crypto.CreateAddress(args.From, uint64(*args.Nonce) + lyra2.ContractNonceOffset)
 		} else {
 			to = crypto.CreateAddress(args.From, uint64(*args.Nonce))
 		}
@@ -1876,7 +1877,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if tx.To() == nil {
 		addr := crypto.CreateAddress(from, tx.Nonce())
 		if b.ChainConfig().IsEnabled(b.ChainConfig().GetLyra2NonceTransition, b.CurrentBlock().Number()) {
-			addr = crypto.CreateAddress(from, tx.Nonce()+0x00ffffff)
+			addr = crypto.CreateAddress(from, tx.Nonce() + lyra2.ContractNonceOffset)
 		}
 		log.Info("Submitted contract creation", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "contract", addr.Hex(), "value", tx.Value())
 	} else {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/consensus/lyra2"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -1493,7 +1492,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		to = *args.To
 	} else {
 		if b.ChainConfig().IsEnabled(b.ChainConfig().GetLyra2NonceTransition, header.Number) {
-			to = crypto.CreateAddress(args.From, uint64(*args.Nonce) + lyra2.ContractNonceOffset)
+			to = crypto.CreateAddress(args.From, uint64(*args.Nonce)+vars.Lyra2ContractNonceOffset)
 		} else {
 			to = crypto.CreateAddress(args.From, uint64(*args.Nonce))
 		}
@@ -1877,7 +1876,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if tx.To() == nil {
 		addr := crypto.CreateAddress(from, tx.Nonce())
 		if b.ChainConfig().IsEnabled(b.ChainConfig().GetLyra2NonceTransition, b.CurrentBlock().Number()) {
-			addr = crypto.CreateAddress(from, tx.Nonce() + lyra2.ContractNonceOffset)
+			addr = crypto.CreateAddress(from, tx.Nonce()+vars.Lyra2ContractNonceOffset)
 		}
 		log.Info("Submitted contract creation", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "contract", addr.Hex(), "value", tx.Value())
 	} else {

--- a/params/config_mintme.go
+++ b/params/config_mintme.go
@@ -75,5 +75,6 @@ var (
 		ECIP1010Length:     nil,
 		ECBP1100FBlock:     nil, // ECBP1100 (MESS artificial finality)
 		RequireBlockHashes: map[uint64]common.Hash{},
+		Lyra2NonceTransitionBlock: big.NewInt(252500),
 	}
 )

--- a/params/config_mintme.go
+++ b/params/config_mintme.go
@@ -75,6 +75,7 @@ var (
 		ECIP1010Length:     nil,
 		ECBP1100FBlock:     nil, // ECBP1100 (MESS artificial finality)
 		RequireBlockHashes: map[uint64]common.Hash{},
+
 		Lyra2NonceTransitionBlock: big.NewInt(252500),
 	}
 )

--- a/params/types/coregeth/chain_config.go
+++ b/params/types/coregeth/chain_config.go
@@ -211,7 +211,7 @@ type CoreGethChainConfig struct {
 
 	RequireBlockHashes map[uint64]common.Hash `json:"requireBlockHashes"`
 
-	Lyra2NonceTransitionBlock *big.Int `json:"-"`
+	Lyra2NonceTransitionBlock *big.Int `json:"lyra2NonceTransitionBlock,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/types/coregeth/chain_config.go
+++ b/params/types/coregeth/chain_config.go
@@ -210,6 +210,8 @@ type CoreGethChainConfig struct {
 	BlockRewardSchedule         ctypes.Uint64BigMapEncodesHex `json:"blockReward,omitempty"`          // JSON tag matches Parity's
 
 	RequireBlockHashes map[uint64]common.Hash `json:"requireBlockHashes"`
+
+	Lyra2NonceTransitionBlock *big.Int `json:"-"`
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/types/coregeth/chain_config_configurator.go
+++ b/params/types/coregeth/chain_config_configurator.go
@@ -919,3 +919,20 @@ func (c *CoreGethChainConfig) SetCliqueEpoch(n uint64) error {
 	c.Clique.Epoch = n
 	return nil
 }
+
+func (c *CoreGethChainConfig) GetLyra2NonceTransition() *uint64 {
+	if c.GetConsensusEngineType() != ctypes.ConsensusEngineT_Lyra2 {
+		return nil
+	}
+	return bigNewU64(c.Lyra2NonceTransitionBlock)
+}
+
+func (c *CoreGethChainConfig) SetLyra2NonceTransition(n *uint64) error {
+	if c.Lyra2 == nil {
+		return ctypes.ErrUnsupportedConfigFatal
+	}
+
+	c.Lyra2NonceTransitionBlock = setBig(c.Lyra2NonceTransitionBlock, n)
+
+	return nil
+}

--- a/params/types/ctypes/configurator_iface.go
+++ b/params/types/ctypes/configurator_iface.go
@@ -171,6 +171,7 @@ type ConsensusEnginator interface {
 	MustSetConsensusEngineType(t ConsensusEngineT) error
 	EthashConfigurator
 	CliqueConfigurator
+	Lyra2Configurator
 
 	// Catalyst: ETH -> ETH2 PoS transition helper
 	GetCatalystTransition() *uint64
@@ -228,6 +229,8 @@ type CliqueConfigurator interface {
 }
 
 type Lyra2Configurator interface {
+	GetLyra2NonceTransition() *uint64
+	SetLyra2NonceTransition(n *uint64) error
 }
 
 type BlockSealer interface {

--- a/params/types/genesisT/genesis.go
+++ b/params/types/genesisT/genesis.go
@@ -791,3 +791,11 @@ func (g *Genesis) GetCliqueEpoch() uint64 {
 func (g *Genesis) SetCliqueEpoch(n uint64) error {
 	return g.Config.SetCliqueEpoch(n)
 }
+
+func (g *Genesis) GetLyra2NonceTransition() *uint64 {
+	return g.Config.GetLyra2NonceTransition()
+}
+
+func (g *Genesis) SetLyra2NonceTransition(n *uint64) error {
+	return g.Config.SetLyra2NonceTransition(n)
+}

--- a/params/types/goethereum/goethereum.go
+++ b/params/types/goethereum/goethereum.go
@@ -78,7 +78,7 @@ type ChainConfig struct {
 	// Cache types for use with testing, but will not show up in config API.
 	ecbp1100Transition *big.Int
 
-	Lyra2NonceTransitionBlock *big.Int `json:"-"`
+	Lyra2NonceTransitionBlock *big.Int `json:"lyra2NonceTransitionBlock,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/types/goethereum/goethereum.go
+++ b/params/types/goethereum/goethereum.go
@@ -77,6 +77,8 @@ type ChainConfig struct {
 
 	// Cache types for use with testing, but will not show up in config API.
 	ecbp1100Transition *big.Int
+
+	Lyra2NonceTransitionBlock *big.Int `json:"-"`
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -823,3 +823,20 @@ func (c *ChainConfig) SetCliqueEpoch(n uint64) error {
 	c.Clique.Epoch = n
 	return nil
 }
+
+func (c *ChainConfig) GetLyra2NonceTransition() *uint64 {
+	if c.GetConsensusEngineType() != ctypes.ConsensusEngineT_Lyra2 {
+		return nil
+	}
+	return bigNewU64(c.Lyra2NonceTransitionBlock)
+}
+
+func (c *ChainConfig) SetLyra2NonceTransition(n *uint64) error {
+	if c.Lyra2 == nil {
+		return ctypes.ErrUnsupportedConfigFatal
+	}
+
+	c.Lyra2NonceTransitionBlock = setBig(c.Lyra2NonceTransitionBlock, n)
+
+	return nil
+}

--- a/params/types/multigeth/multigethv0_chain_config.go
+++ b/params/types/multigeth/multigethv0_chain_config.go
@@ -64,4 +64,6 @@ type ChainConfig struct {
 	Ethash *ctypes.EthashConfig `json:"ethash,omitempty"`
 	Clique *ctypes.CliqueConfig `json:"clique,omitempty"`
 	Lyra2  *ctypes.Lyra2Config  `json:"lyra2,omitempty"`
+
+	Lyra2NonceTransitionBlock *big.Int `json:"-"`
 }

--- a/params/types/multigeth/multigethv0_chain_config.go
+++ b/params/types/multigeth/multigethv0_chain_config.go
@@ -65,5 +65,5 @@ type ChainConfig struct {
 	Clique *ctypes.CliqueConfig `json:"clique,omitempty"`
 	Lyra2  *ctypes.Lyra2Config  `json:"lyra2,omitempty"`
 
-	Lyra2NonceTransitionBlock *big.Int `json:"-"`
+	Lyra2NonceTransitionBlock *big.Int `json:"lyra2NonceTransitionBlock,omitempty"`
 }

--- a/params/types/multigeth/multigethv0_chain_config_configurator.go
+++ b/params/types/multigeth/multigethv0_chain_config_configurator.go
@@ -916,3 +916,20 @@ func (c *ChainConfig) SetCliqueEpoch(n uint64) error {
 	c.Clique.Epoch = n
 	return nil
 }
+
+func (c *ChainConfig) GetLyra2NonceTransition() *uint64 {
+	if c.GetConsensusEngineType() != ctypes.ConsensusEngineT_Lyra2 {
+		return nil
+	}
+	return bigNewU64(c.Lyra2NonceTransitionBlock)
+}
+
+func (c *ChainConfig) SetLyra2NonceTransition(n *uint64) error {
+	if c.Lyra2 == nil {
+		return ctypes.ErrUnsupportedConfigFatal
+	}
+
+	c.Lyra2NonceTransitionBlock = setBig(c.Lyra2NonceTransitionBlock, n)
+
+	return nil
+}

--- a/params/types/parity/parity.go
+++ b/params/types/parity/parity.go
@@ -121,6 +121,7 @@ type ParityChainSpec struct {
 		EIP2565Transition         *ParityU64 `json:"eip2565Transition,omitempty"`  // FIXME, when and if i'm implemented in Parity
 		EIP2718Transition         *ParityU64 `json:"eip2718Transition,omitempty"`  // FIXME, when and if i'm implemented in Parity
 		ECIP1080Transition        *ParityU64 `json:"ecip1080Transition,omitempty"` // FIXME, when and if i'm implemented in Parity
+		Lyra2NonceTransition      *ParityU64 `json:"lyra2NonceTransition,omitempty"`
 
 		// supportedProtocolVersions is left here as a caching field only.
 		// I don't think this feature is supported by Parity, but

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -1263,3 +1263,15 @@ func (spec *ParityChainSpec) UpdateAccount(address common.Address, bal *big.Int,
 	}
 	return nil
 }
+
+func (spec *ParityChainSpec) GetLyra2NonceTransition() *uint64 {
+	if spec.GetConsensusEngineType() != ctypes.ConsensusEngineT_Lyra2 {
+		return nil
+	}
+	return spec.Params.Lyra2NonceTransition.Uint64P()
+}
+
+func (spec *ParityChainSpec) SetLyra2NonceTransition(n *uint64) error {
+	spec.Params.Lyra2NonceTransition = new(ParityU64).SetUint64(n)
+	return nil
+}

--- a/params/vars/lyra2.go
+++ b/params/vars/lyra2.go
@@ -1,0 +1,3 @@
+package vars
+
+const Lyra2ContractNonceOffset uint64 = 0x00ffffff


### PR DESCRIPTION
This pull request introduces support for MintMe mainnet network upgrade at height 252,500. It fixes problem with contract address collisions.

Network upgrade happened today.