### PR TITLE
.github/workflows,.travis.yml: migrate lint and a couple tests to Github Actions

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,4 +1,7 @@
 name: Lint and Tests
+env:
+  # Set to empty.
+  ANDROID_HOME:
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -3,6 +3,8 @@ name: Lint and Tests
 # Controls when the action will run.
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,0 +1,59 @@
+name: Lint and Tests
+
+# Controls when the action will run.
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  # Run linter check. Only test code linters on latest version of Go.
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: false
+
+      - run: make lint
+
+  # Run core-geth -specific tests, proving regression-safety and config interoperability.
+  test-cg:
+    name: Tests-CoreGeth
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - run: make test-coregeth
+
+  # Run build and tests against latest-1 Go version.
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.15
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - run: make test

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -56,4 +56,6 @@ jobs:
         with:
           submodules: recursive
 
-      - run: make test
+      - run: |
+          make all
+          make test

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -14,11 +14,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         id: go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
 
       - uses: actions/checkout@v2
         with:
@@ -31,11 +31,11 @@ jobs:
     name: Tests-CoreGeth
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         id: go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
 
       - uses: actions/checkout@v2
         with:
@@ -48,11 +48,11 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         id: go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - uses: actions/checkout@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,39 +4,6 @@ sudo: false
 jobs:
   include:
 
-  # Run linter check. Only test code linters on latest version of Go.
-  - stage: lint
-    os: linux
-    dist: xenial
-    go: 1.16.x
-    env:
-      - lint
-    git:
-      submodules: false
-    script:
-      - make lint
-
-  # Run core-geth -specific tests, proving regression-safety and config interoperability.
-  - stage: build
-    name: "Go1.16.x: make test-coregeth"
-    os: linux
-    dist: xenial
-    go: 1.16.x
-    script:
-    - travis_wait 60 make test-coregeth
-
-  # Run build and tests against latest-1 Go version.
-  - stage: build
-    name: "Go1.15.x: make test"
-    os: linux
-    dist: xenial
-    go: 1.15.x
-    env:
-      - GO111MODULE=on
-    script:
-      - make all
-      - travis_wait 60 make test
-
   # Run build and tests on ARM64 on Pull Requests.
   # These tests are divided in half because their aggregate typical runtime
   # exceeds Travis' time limit (~60m) and were consistently causing timeouts.


### PR DESCRIPTION
Travis has a new _Credit_ system that ~~coregeth~~ etclabscore/ is using up (1000 minutes / month) causing Travis to not run anymore until the new month rolls over.

This PR migrates the `make lint` check and a couple simple tests to Github Actions to remove some of the minutes from Travis.

It doesn't touch any Travis jobs that handle deploys (on tags). This is possible in the future, but I just want to get the easy stuff moved over first.