### PR TITLE
Fix trace_block for stateDiffTracer

### DIFF
--- a/eth/tracers/api_parity.go
+++ b/eth/tracers/api_parity.go
@@ -212,11 +212,15 @@ func (api *TraceAPI) Block(ctx context.Context, number rpc.BlockNumber, config *
 	results := []interface{}{}
 
 	for _, result := range traceResults {
-		var tmp []interface{}
+		var tmp interface{}
 		if err := json.Unmarshal(result.Result.(json.RawMessage), &tmp); err != nil {
 			return nil, err
 		}
-		results = append(results, tmp...)
+		if *config.Tracer == "stateDiffTracer" {
+			results = append(results, tmp)
+		} else {
+			results = append(results, tmp.([]interface{})...)
+		}
 	}
 
 	results = append(results, traceReward)


### PR DESCRIPTION
Fix `trace_block` when used with the `stateDiffTracer`, as the `trace_block` was expecting an array while `stateDiff` returns a JS object.

This has been tested on classic.

Before fix:
```
> trace.block('0x4BAF8', {"tracer":"stateDiffTracer"})
Error: method handler crashed
        at web3.js:6347:37(47)
        at web3.js:5081:62(37)
        at <eval>:1:12(7)
```

After fix:
```
> trace.block('0x4BAF8', {"tracer":"stateDiffTracer"})
[{}, {
    action: {
      author: "0x7e6930b63d03e88f5928c5cd6ee3fcee4d714f7f",
      rewardType: "block",
      value: "0x4563918244f40000"
    },
    blockHash: "0x8cd39d130fd3eb24296c571a5d4bf29f47b236538e297e1b009fae8ad0b9ffbe",
    blockNumber: 310008,
    result: null,
    subtraces: 0,
    traceAddress: [],
    transactionHash: null,
    transactionPosition: null,
    type: "reward"
}]
```