### PR TITLE
Tests/generate mystique

### DIFF
--- a/params/types/multigeth/multigethv0_chain_config_configurator.go
+++ b/params/types/multigeth/multigethv0_chain_config_configurator.go
@@ -494,28 +494,6 @@ func (c *ChainConfig) GetEIP1559Transition() *uint64 {
 }
 
 func (c *ChainConfig) SetEIP1559Transition(n *uint64) error {
-	if n == nil && c.LondonBlock != nil {
-		// Once set, the London feature batch cannot be unset.
-		// This is annoying, but necessary.
-		// The core-geth configuration interface pattern
-		// allows only SOME features from the London fork to be
-		// activated.
-		// In programmatically converting between the two
-		// interface types (core-geth vs. go-ethereum|multi-geth),
-		// configurations are unilaterally specific;
-		// all configurations available with the go-ethereum config
-		// can be represented in the core-geth config;
-		// BUT not all configurations possible with the core-geth
-		// config are possible with the go-ethereum config.
-		//
-		// So we hack it.
-		// We know the conventional use case for this problem;
-		// translating configuration types for tests, usually
-		// where the configs are defaults.
-		// We know that Ethereum Classic implements partial sets
-		// of fork-feature sets on Ethereum Foundation.
-		return ctypes.ErrUnsupportedConfigNoop
-	}
 	c.LondonBlock = setBig(c.LondonBlock, n)
 	return nil
 }
@@ -525,9 +503,6 @@ func (c *ChainConfig) GetEIP3541Transition() *uint64 {
 }
 
 func (c *ChainConfig) SetEIP3541Transition(n *uint64) error {
-	if n == nil && c.LondonBlock != nil {
-		return ctypes.ErrUnsupportedConfigNoop
-	}
 	c.LondonBlock = setBig(c.LondonBlock, n)
 	return nil
 }
@@ -537,9 +512,6 @@ func (c *ChainConfig) GetEIP3529Transition() *uint64 {
 }
 
 func (c *ChainConfig) SetEIP3529Transition(n *uint64) error {
-	if n == nil && c.LondonBlock != nil {
-		return ctypes.ErrUnsupportedConfigNoop
-	}
 	c.LondonBlock = setBig(c.LondonBlock, n)
 	return nil
 }

--- a/params/types/multigeth/multigethv0_chain_config_configurator.go
+++ b/params/types/multigeth/multigethv0_chain_config_configurator.go
@@ -494,6 +494,28 @@ func (c *ChainConfig) GetEIP1559Transition() *uint64 {
 }
 
 func (c *ChainConfig) SetEIP1559Transition(n *uint64) error {
+	if n == nil && c.LondonBlock != nil {
+		// Once set, the London feature batch cannot be unset.
+		// This is annoying, but necessary.
+		// The core-geth configuration interface pattern
+		// allows only SOME features from the London fork to be
+		// activated.
+		// In programmatically converting between the two
+		// interface types (core-geth vs. go-ethereum|multi-geth),
+		// configurations are unilaterally specific;
+		// all configurations available with the go-ethereum config
+		// can be represented in the core-geth config;
+		// BUT not all configurations possible with the core-geth
+		// config are possible with the go-ethereum config.
+		//
+		// So we hack it.
+		// We know the conventional use case for this problem;
+		// translating configuration types for tests, usually
+		// where the configs are defaults.
+		// We know that Ethereum Classic implements partial sets
+		// of fork-feature sets on Ethereum Foundation.
+		return ctypes.ErrUnsupportedConfigNoop
+	}
 	c.LondonBlock = setBig(c.LondonBlock, n)
 	return nil
 }
@@ -503,6 +525,9 @@ func (c *ChainConfig) GetEIP3541Transition() *uint64 {
 }
 
 func (c *ChainConfig) SetEIP3541Transition(n *uint64) error {
+	if n == nil && c.LondonBlock != nil {
+		return ctypes.ErrUnsupportedConfigNoop
+	}
 	c.LondonBlock = setBig(c.LondonBlock, n)
 	return nil
 }
@@ -512,6 +537,9 @@ func (c *ChainConfig) GetEIP3529Transition() *uint64 {
 }
 
 func (c *ChainConfig) SetEIP3529Transition(n *uint64) error {
+	if n == nil && c.LondonBlock != nil {
+		return ctypes.ErrUnsupportedConfigNoop
+	}
 	c.LondonBlock = setBig(c.LondonBlock, n)
 	return nil
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -370,6 +370,65 @@ var Forks = map[string]ctypes.ChainConfigurator{
 		ECIP1010PauseBlock: nil,
 		ECIP1010Length:     nil,
 	},
+	"ETC_Mystique": &coregeth.CoreGethChainConfig{
+		NetworkID:       1,
+		Ethash:          new(ctypes.EthashConfig),
+		ChainID:         big.NewInt(61),
+		EIP2FBlock:      big.NewInt(0),
+		EIP7FBlock:      big.NewInt(0),
+		EIP150Block:     big.NewInt(0),
+		EIP155Block:     big.NewInt(0),
+		EIP160FBlock:    big.NewInt(0),
+		EIP161FBlock:    big.NewInt(0),
+		EIP170FBlock:    big.NewInt(0),
+		EIP100FBlock:    big.NewInt(0),
+		EIP140FBlock:    big.NewInt(0),
+		EIP198FBlock:    big.NewInt(0),
+		EIP211FBlock:    big.NewInt(0),
+		EIP212FBlock:    big.NewInt(0),
+		EIP213FBlock:    big.NewInt(0),
+		EIP214FBlock:    big.NewInt(0),
+		EIP658FBlock:    big.NewInt(0),
+		EIP145FBlock:    big.NewInt(0),
+		EIP1014FBlock:   big.NewInt(0),
+		EIP1052FBlock:   big.NewInt(0),
+		EIP1283FBlock:   big.NewInt(0),
+		PetersburgBlock: big.NewInt(0),
+		// Istanbul eq, aka Phoenix
+		// ECIP-1088
+		EIP152FBlock:  big.NewInt(0),
+		EIP1108FBlock: big.NewInt(0),
+		EIP1344FBlock: big.NewInt(0),
+		EIP1884FBlock: big.NewInt(0),
+		EIP2028FBlock: big.NewInt(0),
+		EIP2200FBlock: big.NewInt(0), // RePetersburg (=~ re-1283)
+
+		// Berlin
+		EIP2565FBlock: big.NewInt(0),
+		EIP2929FBlock: big.NewInt(0),
+		EIP2718FBlock: big.NewInt(0),
+		EIP2930FBlock: big.NewInt(0),
+
+		// London
+		/*
+			3529 (Alternative refund reduction) 	#22733 	Include
+			3541 (Reject new contracts starting with the 0xEF byte) 	#22809 	Include
+			1559 (Fee market change) 	#22837 #22896 	Omit
+			3198 (BASEFEE opcode) 	#22837 	Omit
+			3228 (bomb delay) 	#22840 and #22870 	Omit
+		*/
+		EIP3529FBlock: big.NewInt(0),
+		EIP3541FBlock: big.NewInt(0),
+		EIP1559FBlock: nil,
+		EIP3198FBlock: nil,
+		EIP3554FBlock: nil,
+
+		DisposalBlock:      big.NewInt(0),
+		ECIP1017FBlock:     big.NewInt(5000000), // FIXME(meows) maybe
+		ECIP1017EraRounds:  big.NewInt(5000000),
+		ECIP1010PauseBlock: nil,
+		ECIP1010Length:     nil,
+	},
 }
 
 // Returns the set of defined fork names

--- a/tests/init.go
+++ b/tests/init.go
@@ -411,6 +411,8 @@ var Forks = map[string]ctypes.ChainConfigurator{
 
 		// London
 		/*
+			https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1104.md
+
 			3529 (Alternative refund reduction) 	#22733 	Include
 			3541 (Reject new contracts starting with the 0xEF byte) 	#22809 	Include
 			1559 (Fee market change) 	#22837 #22896 	Omit

--- a/tests/state_mgen_test.go
+++ b/tests/state_mgen_test.go
@@ -104,6 +104,7 @@ func TestGenStateAll(t *testing.T) {
 	tm.generateFromReference("ConstantinopleFix", "ETC_Agharta")
 	tm.generateFromReference("Berlin", "ETC_Magneto")
 	tm.generateFromReference("Istanbul", "ETC_Phoenix")
+	tm.generateFromReference("London", "ETC_Mystique")
 
 	for _, dir := range []string{
 		stateTestDir,

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -69,18 +70,21 @@ func TestState(t *testing.T) {
 		st.skipFork("Magneto")
 		st.skipFork("London")
 	}
+	if os.Getenv(CG_CHAINCONFIG_FEATURE_EQ_MULTIGETHV0_KEY) != "" {
+		st.skipFork("ETC_Mystique")
+	}
 
 	// Un-skip this when https://github.com/ethereum/tests/issues/908 is closed
 	st.skipLoad(`^stQuadraticComplexityTest/QuadraticComplexitySolidity_CallDataCopy`)
 
 	// Broken tests:
 	// Expected failures:
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/0`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/3`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/0`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/3`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/0`, "bug in test")
-	//st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/3`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/0`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Byzantium/3`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/0`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/Constantinople/3`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/0`, "bug in test")
+	// st.fails(`^stRevertTest/RevertPrecompiledTouch(_storage)?\.json/ConstantinopleFix/3`, "bug in test")
 
 	// For Istanbul, older tests were moved into LegacyTests
 	for _, dir := range []string{

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -70,6 +70,9 @@ func TestState(t *testing.T) {
 		st.skipFork("Magneto")
 		st.skipFork("London")
 	}
+	// The multigeth data type (like the Ethereum Foundation data type) doesn't support
+	// the ETC_Mystique fork/feature configuration, which omits EIP1559 and the associated BASEFEE
+	// opcode stuff. This configuration cannot be represented in their struct.
 	if os.Getenv(CG_CHAINCONFIG_FEATURE_EQ_MULTIGETHV0_KEY) != "" {
 		st.skipFork("ETC_Mystique")
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -66,9 +66,10 @@ func TestState(t *testing.T) {
 	if *testEVM != "" || *testEWASM != "" {
 		// Berlin tests are not expected to pass for external EVMs, yet.
 		//
-		st.skipFork("^Berlin$")
-		st.skipFork("Magneto")
-		st.skipFork("London")
+		st.skipFork("^Berlin$") // ETH
+		st.skipFork("Magneto")  // ETC
+		st.skipFork("London")   // ETH
+		st.skipFork("Mystique") // ETC
 	}
 	// The multigeth data type (like the Ethereum Foundation data type) doesn't support
 	// the ETC_Mystique fork/feature configuration, which omits EIP1559 and the associated BASEFEE


### PR DESCRIPTION
Generates and includes `GeneralStateTests` for the `ETC_Mystique` test configuration.
This configuration is spec'd here: https://github.com/ethereumclassic/ECIPs/pull/452/files#diff-d5496c21eb89f07be78b9bbf3399a610defa66676e25cc5f803eef279a873b35.

I ran the generation program twice to provide some redundancy given potentially nondeterministic conditions (at least Go's un-guaranteed map ordering). The first of these is used for this pull request; the latter should be discarded after review.

https://github.com/etclabscore/core-geth/tree/tests/generate-mystique
https://github.com/etclabscore/core-geth/tree/tests/generate-mystique2