### PR TITLE
Ci/linux artifact glibc compiler

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -23,6 +23,9 @@ jobs:
         - os: ubuntu-latest
           BUILD_OS_NAME: linux
 
+        - os: ubuntu-18.04
+            BUILD_OS_NAME: linux_bionic
+
         - os: ubuntu-latest
           BUILD_OS_NAME: arm
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -20,13 +20,14 @@ jobs:
         - os: macos-latest
           BUILD_OS_NAME: osx
 
-        - os: ubuntu-latest
+        # Build on 18.04 (Bionic) because the OS GLIBC is bumped above 2.26 in later versions (eg. 20.04).
+        # This GLIBC version included and used by default in at least Amazon Linux 2 and Ubuntu Bionic.
+        # The C compiler used by default in the 18.04 runner produces an executable which is runnable
+        # on Ubuntu Disco and Focal (tested by meowsbits); it is forward compatible.  
+        - os: ubuntu-18.04
           BUILD_OS_NAME: linux
 
         - os: ubuntu-18.04
-          BUILD_OS_NAME: linux_bionic
-
-        - os: ubuntu-latest
           BUILD_OS_NAME: arm
 
         - os: windows-latest

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -24,7 +24,7 @@ jobs:
           BUILD_OS_NAME: linux
 
         - os: ubuntu-18.04
-            BUILD_OS_NAME: linux_bionic
+          BUILD_OS_NAME: linux_bionic
 
         - os: ubuntu-latest
           BUILD_OS_NAME: arm


### PR DESCRIPTION
Fixes #438. The produced Linux artifacts are runnable out of the box (as tested) against 18.04, 19.04, and 20.4. Have not tested against 16.04. 