### PR TITLE
cmd/utils: fix --dev mode Fatalf for genesis conf

### DIFF
--- a/cmd/geth/consolecmd_cg_test.go
+++ b/cmd/geth/consolecmd_cg_test.go
@@ -39,6 +39,8 @@ func TestConsoleCmdNetworkIdentities(t *testing.T) {
 		{[]string{"--kotti"}, 6, 6, params.KottiGenesisHash.Hex()},
 		{[]string{"--mordor"}, 7, 63, params.MordorGenesisHash.Hex()},
 		{[]string{"--mintme"}, 37480, 24734, params.MintMeGenesisHash.Hex()},
+		{[]string{"--dev"}, 1337, 1337, "0x0"},
+		{[]string{"--dev.pow"}, 1337, 1337, "0x0"},
 	}
 	for i, p := range chainIdentityCases {
 
@@ -50,8 +52,12 @@ func TestConsoleCmdNetworkIdentities(t *testing.T) {
 			consoleCmdStdoutTest(p.flags, "admin.nodeInfo.protocols.eth.network", p.networkId))
 		t.Run(fmt.Sprintf("%d/%v/chainid", i, p.flags),
 			consoleCmdStdoutTest(p.flags, "admin.nodeInfo.protocols.eth.config.chainId", p.chainId))
-		t.Run(fmt.Sprintf("%d/%v/genesis_hash", i, p.flags),
-			consoleCmdStdoutTest(p.flags, "eth.getBlock(0, false).hash", strconv.Quote(p.genesisHash)))
+
+		// The developer mode block has a dynamic genesis, depending on a parameterized address (coinbase) value.
+		if p.genesisHash != "0x0" {
+			t.Run(fmt.Sprintf("%d/%v/genesis_hash", i, p.flags),
+				consoleCmdStdoutTest(p.flags, "eth.getBlock(0, false).hash", strconv.Quote(p.genesisHash)))
+		}
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1756,8 +1756,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Override any default configs for hard coded networks.
 
 	// Override genesis configuration if a --<chain> flag.
-	if gen := genesisForCtxChainConfig(ctx); gen != nil {
-		cfg.Genesis = gen
+	if !ctx.GlobalBool(DeveloperFlag.Name) && !ctx.GlobalBool(DeveloperPoWFlag.Name) {
+		if gen := genesisForCtxChainConfig(ctx); gen != nil {
+			cfg.Genesis = gen
+		}
 	}
 
 	// Establish NetworkID.


### PR DESCRIPTION
Using --dev flag caused geth to
Fatalf. The program was trying to
install the genesis, where each
of two genesis resolution logics
fataled under dev mode. Apparently
dev mode does not use normal people's
genesis functions.

This seems to make it work.

Date: 2022-02-02 07:44:57-08:00
Signed-off-by: meows <b5c6@protonmail.com>