### PR TITLE
Ci/fix bench

### DIFF
--- a/.github/workflows/bench-core.yml
+++ b/.github/workflows/bench-core.yml
@@ -73,9 +73,7 @@ jobs:
 
       - name: Get dependencies
         run: |
-          cd ..
-          go get golang.org/x/perf/cmd/...
-          cd -
+          go install golang.org/x/perf/cmd/benchstat@latest
 
       - uses: actions/download-artifact@v2
         name: Get go-ethereum artifact

--- a/.github/workflows/bench-trie.yml
+++ b/.github/workflows/bench-trie.yml
@@ -73,9 +73,7 @@ jobs:
 
       - name: Get dependencies
         run: |
-          cd ..
-          go get golang.org/x/perf/cmd/...
-          cd -
+          go install golang.org/x/perf/cmd/benchstat@latest
 
       - uses: actions/download-artifact@v2
         name: Get go-ethereum artifact

--- a/.github/workflows/bench-vm.yml
+++ b/.github/workflows/bench-vm.yml
@@ -79,9 +79,7 @@ jobs:
 
       - name: Get dependencies
         run: |
-          cd ..
-          go get golang.org/x/perf/cmd/...
-          cd -
+          go install golang.org/x/perf/cmd/benchstat@latest
 
       - uses: actions/download-artifact@v2
         name: Get go-ethereum artifact

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -55,11 +55,9 @@ func BenchmarkInsertChain_valueTx_100kB_diskdb(b *testing.B) {
 	benchInsertChain(b, true, genValueTx(100*1024))
 }
 func BenchmarkInsertChain_uncles_memdb(b *testing.B) {
-	b.Skip("pending upstream resolution of https://github.com/ethereum/go-ethereum/issues/24654")
 	benchInsertChain(b, false, genUncles)
 }
 func BenchmarkInsertChain_uncles_diskdb(b *testing.B) {
-	b.Skip("pending upstream resolution of https://github.com/ethereum/go-ethereum/issues/24654")
 	benchInsertChain(b, true, genUncles)
 }
 func BenchmarkInsertChain_ring200_memdb(b *testing.B) {

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -166,7 +166,7 @@ func genTxRing(naccounts int) func(int, *BlockGen) {
 
 // genUncles generates blocks with two uncle headers.
 func genUncles(i int, gen *BlockGen) {
-	if i >= 6 {
+	if i >= 7 {
 		b2 := gen.PrevBlock(i - 6).Header()
 		b2.Extra = []byte("foo")
 		gen.AddUncle(b2)


### PR DESCRIPTION
- Fixes the installation of `benchstat` dependency for benchmark output comparison.
- Fixes and un-skips two benchmark tests. See https://github.com/ethereum/go-ethereum/pull/24657.