### PR TITLE
Ci/fix jenkins go version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo mv /usr/local/go/bin/* /usr/bin/"
+                        sh "sudo cp /usr/local/go/bin/* /usr/bin/"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-kotti"
@@ -42,7 +42,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo mv /usr/local/go/bin/* /usr/bin/"
+                        sh "sudo cp /usr/local/go/bin/* /usr/bin/"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-mordor"
@@ -61,7 +61,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo mv /usr/local/go/bin/* /usr/bin/"
+                        sh "sudo cp /usr/local/go/bin/* /usr/bin/"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-goerli"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm $(which go)"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -42,6 +43,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm $(which go)"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -61,6 +63,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm $(which go)"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -41,7 +41,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -60,7 +60,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "which go"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "export PATH=$PATH:/usr/local/go/bin"
+                        sh "sudo mv /usr/local/go/bin/* /usr/bin/"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-kotti"
@@ -42,7 +42,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "export PATH=$PATH:/usr/local/go/bin"
+                        sh "sudo mv /usr/local/go/bin/* /usr/bin/"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-mordor"
@@ -61,7 +61,7 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "export PATH=$PATH:/usr/local/go/bin"
+                        sh "sudo mv /usr/local/go/bin/* /usr/bin/"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-goerli"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,9 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo cp /usr/local/go/bin/* /usr/bin/"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
+                        sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-kotti"
@@ -41,8 +42,9 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo cp /usr/local/go/bin/* /usr/bin/"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
+                        sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-mordor"
@@ -60,8 +62,9 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo cp /usr/local/go/bin/* /usr/bin/"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
+                        sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-goerli"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -41,7 +41,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -60,7 +60,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,10 @@ pipeline {
                 stage('Kotti') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
+                        sh "curl -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
+                        sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "export PATH=$PATH:/usr/local/go/bin"
+                        sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-kotti"
                         sh "shasum -a 256 -c ./tests/regression/shasums/kotti.0-2544960.rlp.gz.sha256"
@@ -36,6 +40,10 @@ pipeline {
                 stage('Mordor') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
+                        sh "curl -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
+                        sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "export PATH=$PATH:/usr/local/go/bin"
+                        sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-mordor"
                         sh "shasum -a 256 -c ./tests/regression/shasums/mordor.0-1686858.rlp.gz.sha256"
@@ -51,6 +59,10 @@ pipeline {
                 stage('Goerli') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
+                        sh "curl -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
+                        sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "export PATH=$PATH:/usr/local/go/bin"
+                        sh "go version"
                         sh "make geth && ./build/bin/geth version"
                         sh "rm -rf ${GETH_DATADIR}-goerli"
                         sh "shasum -a 256 -c ./tests/regression/shasums/goerli.0-2000000.rlp.gz.sha256"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm $(which go)"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -43,7 +42,6 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm $(which go)"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -63,7 +61,6 @@ pipeline {
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm $(which go)"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 stage('Kotti') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
@@ -40,7 +40,7 @@ pipeline {
                 stage('Mordor') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
@@ -59,7 +59,7 @@ pipeline {
                 stage('Goerli') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
                         sh "rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
-                        sh "which go"
+                        sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -42,7 +41,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"
@@ -61,7 +60,7 @@ pipeline {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
                         sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
                         sh "export PATH=$PATH:/usr/local/go/bin"
                         sh "go version"
                         sh "make geth && ./build/bin/geth version"


### PR DESCRIPTION
The Jenkins pipeline which handles regression tests started failing. I believe this is because of out-of-date Go versions on the EC2 instances. The failure is here: https://ci.etccore.in/blue/organizations/jenkins/core-geth-regression/detail/core-geth-regression/233/pipeline.

Current pipeline version:

```
go version go1.14.4 linux/amd64
```

I've encountered a similar error locally before and I was able to resolve it by upgrading my local Go version, so that's what I'm trying here.