### PR TITLE
Merge/foundation release/1.10.21 tests generate

### DIFF
--- a/params/coregeth.json.d/custom_mainnetwork_difficulty_test.json
+++ b/params/coregeth.json.d/custom_mainnetwork_difficulty_test.json
@@ -1,6 +1,9 @@
 {
     "networkId": 1,
     "chainId": 1,
+    "supportedProtocolVersions": [
+        66
+    ],
     "eip2FBlock": 1150000,
     "eip7FBlock": 1150000,
     "daoForkBlock": 1920000,

--- a/params/coregeth.json.d/difficulty_json_difficulty_test.json
+++ b/params/coregeth.json.d/difficulty_json_difficulty_test.json
@@ -2,8 +2,7 @@
     "networkId": 1,
     "chainId": 1,
     "supportedProtocolVersions": [
-        66,
-        65
+        66
     ],
     "eip2FBlock": 1150000,
     "eip7FBlock": 1150000,

--- a/params/coregeth.json.d/mainnetwork_difficulty_test.json
+++ b/params/coregeth.json.d/mainnetwork_difficulty_test.json
@@ -2,8 +2,7 @@
     "networkId": 1,
     "chainId": 1,
     "supportedProtocolVersions": [
-        66,
-        65
+        66
     ],
     "eip2FBlock": 1150000,
     "eip7FBlock": 1150000,

--- a/params/coregeth.json.d/ropsten_difficulty_test.json
+++ b/params/coregeth.json.d/ropsten_difficulty_test.json
@@ -2,8 +2,7 @@
     "networkId": 3,
     "chainId": 3,
     "supportedProtocolVersions": [
-        66,
-        65
+        66
     ],
     "eip2FBlock": 0,
     "eip7FBlock": 0,
@@ -42,6 +41,7 @@
     "eip3541FBlock": 10499401,
     "eip3529FBlock": 10499401,
     "ethash": {},
+    "terminalTotalDifficulty": 50000000000000000,
     "difficultyBombDelays": {
         "0x19f0a0": "0x2dc6c0",
         "0x408b70": "0x1e8480",

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -65,9 +65,8 @@ var (
 	legacyStateTestDir = filepath.Join(baseDir, "LegacyTests", "Constantinople", "GeneralStateTests")
 	transactionTestDir = filepath.Join(baseDir, "TransactionTests")
 	rlpTestDir         = filepath.Join(baseDir, "RLPTests")
-	// difficultyTestDir  = filepath.Join(baseDir, "BasicTests.core-geth")
-	difficultyTestDir = filepath.Join(baseDir, "BasicTests")
-	benchmarksDir     = filepath.Join(".", "evm-benchmarks", "benchmarks")
+	difficultyTestDir  = filepath.Join(baseDir, "BasicTests")
+	benchmarksDir      = filepath.Join(".", "evm-benchmarks", "benchmarks")
 )
 
 func readJSON(reader io.Reader, value interface{}) error {

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -65,8 +65,9 @@ var (
 	legacyStateTestDir = filepath.Join(baseDir, "LegacyTests", "Constantinople", "GeneralStateTests")
 	transactionTestDir = filepath.Join(baseDir, "TransactionTests")
 	rlpTestDir         = filepath.Join(baseDir, "RLPTests")
-	difficultyTestDir  = filepath.Join(baseDir, "BasicTests.core-geth")
-	benchmarksDir      = filepath.Join(".", "evm-benchmarks", "benchmarks")
+	// difficultyTestDir  = filepath.Join(baseDir, "BasicTests.core-geth")
+	difficultyTestDir = filepath.Join(baseDir, "BasicTests")
+	benchmarksDir     = filepath.Join(".", "evm-benchmarks", "benchmarks")
 )
 
 func readJSON(reader io.Reader, value interface{}) error {


### PR DESCRIPTION
- updates the cross-client test suites to use the latest version per upstream ethereum/go-ethereum as reference
- updates and occasionally fixes cross-client test generation logic

notes

- LegacyTests are now a submodule of the `tests/testdata` submodule, forked here https://github.com/etclabscore/legacytests
  + checkouts now need to be sure to use `git submodule update --recursive [--init]`
  + this is a change from upstream
- todos and comments will be marked inline in the patch view below
 