### PR TITLE
fix Etchash cache at Mordor

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -303,7 +303,7 @@ func generateDataset(dest []uint32, epoch uint64, epochLength uint64, cache []ui
 		if elapsed > 3*time.Second {
 			logFn = logger.Info
 		}
-		logFn("Generated ethash verification cache", "epochLength", epochLength, "elapsed", common.PrettyDuration(elapsed))
+		logFn("Generated ethash verification dataset", "epochLength", epochLength, "elapsed", common.PrettyDuration(elapsed))
 	}()
 
 	// Figure out whether the bytes need to be swapped for the machine

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -463,7 +463,7 @@ func (d *dataset) generate(dir string, limit int, lock bool, test bool) {
 		if !isLittleEndian() {
 			endian = ".be"
 		}
-		path := filepath.Join(dir, fmt.Sprintf("full-R%d-%x%s", algorithmRevision, seed[:8], endian))
+		path := filepath.Join(dir, fmt.Sprintf("full-R%d-%d-%x%s", algorithmRevision, d.epoch, seed[:8], endian))
 		logger := log.New("epoch", d.epoch)
 
 		// We're about to mmap the file, ensure that the mapping is cleaned up when the
@@ -499,11 +499,34 @@ func (d *dataset) generate(dir string, limit int, lock bool, test bool) {
 			d.dataset = make([]uint32, dsize/4)
 			generateDataset(d.dataset, d.epoch, d.epochLength, cache)
 		}
-		// Iterate over all previous instances and delete old ones
-		for ep := int(d.epoch) - limit; ep >= 0; ep-- {
-			seed := seedHash(uint64(ep), d.epochLength)
-			path := filepath.Join(dir, fmt.Sprintf("full-R%d-%x%s", algorithmRevision, seed[:8], endian))
-			os.Remove(path)
+
+		// Iterate over all full file instances, deleting any out of bounds (where epoch is below lower limit, or above upper limit).
+		matches, _ := filepath.Glob(filepath.Join(dir, fmt.Sprintf("full-R%d*", algorithmRevision)))
+		for _, file := range matches {
+			var ar int   // algorithm revision
+			var e uint64 // epoch
+			var s string // seed
+			if _, err := fmt.Sscanf(filepath.Base(file), "full-R%d-%d-%s"+endian, &ar, &e, &s); err != nil {
+				// There is an unrecognized file in this directory.
+				// See if the name matches the expected pattern of the legacy naming scheme.
+				if _, err := fmt.Sscanf(filepath.Base(file), "full-R%d-%s"+endian, &ar, &s); err == nil {
+					// This file matches the previous generation naming pattern (sans epoch).
+					if err := os.Remove(file); err != nil {
+						logger.Error("Failed to remove legacy ethash full file", "file", file, "err", err)
+					} else {
+						logger.Warn("Deleted legacy ethash full file", "path", file)
+					}
+				}
+				// Else the file is unrecognized (unknown name format), leave it alone.
+				continue
+			}
+			if e <= d.epoch-uint64(limit) || e > d.epoch+1 {
+				if err := os.Remove(file); err == nil {
+					logger.Debug("Deleted ethash full file", "target.epoch", e, "file", file)
+				} else {
+					logger.Error("Failed to delete ethash full file", "target.epoch", e, "file", file, "err", err)
+				}
+			}
 		}
 	})
 }

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -244,7 +244,10 @@ func (lru *lru) get(epoch uint64, epochLength uint64, ecip1099FBlock *uint64) (i
 	var nextEpochLength = epochLength
 	if ecip1099FBlock != nil {
 		nextEpochBlock := nextEpoch * epochLength
-		if nextEpochBlock >= *ecip1099FBlock && epochLength == epochLengthDefault {
+		// Note that == demands that the ECIP1099 activation block is situated
+		// at the beginning of an epoch.
+		// https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1099.md#implementation
+		if nextEpochBlock == *ecip1099FBlock && epochLength == epochLengthDefault {
 			nextEpoch = nextEpoch / 2
 			nextEpochLength = epochLengthECIP1099
 		}

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -392,9 +392,8 @@ func (c *cache) generate(dir string, limit int, lock bool, test bool) {
 					} else {
 						logger.Warn("Deleted legacy ethash cache file", "path", file)
 					}
-				} else {
-					// Else the file is unrecognized (unknown name format), leave it alone.
 				}
+				// Else the file is unrecognized (unknown name format), leave it alone.
 				continue
 			}
 			if e <= c.epoch-uint64(limit) || e > c.epoch+1 {

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -244,7 +244,7 @@ func (lru *lru) get(epoch uint64, epochLength uint64, ecip1099FBlock *uint64) (i
 	var nextEpochLength = epochLength
 	if ecip1099FBlock != nil {
 		nextEpochBlock := nextEpoch * epochLength
-		if nextEpochBlock == *ecip1099FBlock && epochLength == epochLengthDefault {
+		if nextEpochBlock >= *ecip1099FBlock && epochLength == epochLengthDefault {
 			nextEpoch = nextEpoch / 2
 			nextEpochLength = epochLengthECIP1099
 		}

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -250,7 +250,9 @@ func (lru *lru) get(epoch uint64, epochLength uint64, ecip1099FBlock *uint64) (i
 	}
 
 	// Update the 'future item' if epoch is larger than previously seen.
-	if epoch < maxEpoch-1 && lru.future < nextEpoch {
+	// Last conditional clause ('lru.future > nextEpoch') handles the ECIP1099 case where
+	// the next epoch is expected to be LESSER THAN that of the previous state's future epoch number.
+	if epoch < maxEpoch-1 && (lru.future < nextEpoch || lru.future > nextEpoch) {
 		log.Trace("Requiring new future ethash "+lru.what, "epoch", nextEpoch)
 		future = lru.new(nextEpoch, nextEpochLength)
 		lru.future = nextEpoch

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -226,8 +226,9 @@ func (lru *lru) get(epoch uint64, epochLength uint64, ecip1099FBlock *uint64) (i
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
 
+	cacheKey := fmt.Sprintf("%d-%d", epoch, epochLength)
 	// Get or create the item for the requested epoch.
-	item, ok := lru.cache.Get(epoch)
+	item, ok := lru.cache.Get(cacheKey)
 	if !ok {
 		if lru.future > 0 && lru.future == epoch {
 			item = lru.futureItem
@@ -235,7 +236,7 @@ func (lru *lru) get(epoch uint64, epochLength uint64, ecip1099FBlock *uint64) (i
 			log.Trace("Requiring new ethash "+lru.what, "epoch", epoch)
 			item = lru.new(epoch, epochLength)
 		}
-		lru.cache.Add(epoch, item)
+		lru.cache.Add(cacheKey, item)
 	}
 
 	// Ensure pre-generation handles ecip-1099 changeover correctly

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -253,7 +253,7 @@ func (lru *lru) get(epoch uint64, epochLength uint64, ecip1099FBlock *uint64) (i
 	// Update the 'future item' if epoch is larger than previously seen.
 	// Last conditional clause ('lru.future > nextEpoch') handles the ECIP1099 case where
 	// the next epoch is expected to be LESSER THAN that of the previous state's future epoch number.
-	if epoch < maxEpoch-1 && (lru.future < nextEpoch || lru.future > nextEpoch) {
+	if epoch < maxEpoch-1 && lru.future != nextEpoch {
 		log.Trace("Requiring new future ethash "+lru.what, "epoch", nextEpoch)
 		future = lru.new(nextEpoch, nextEpochLength)
 		lru.future = nextEpoch

--- a/consensus/ethash/ethash_test.go
+++ b/consensus/ethash/ethash_test.go
@@ -73,7 +73,6 @@ func TestEthashCaches(t *testing.T) {
 	trialMax := ecip1099Block * uint64(testIterationMultiple) * 2
 	latestIteratedEpoch := uint64(math.MaxInt64)
 	for n := uint64(0); n < trialMax; n += epochLengthDefault / 300 {
-
 		// Calculate the epoch number independently to use for logging and debugging.
 		epochLength := epochLengthDefault
 		if n >= ecip1099Block {

--- a/consensus/ethash/ethash_test.go
+++ b/consensus/ethash/ethash_test.go
@@ -143,7 +143,7 @@ func TestEthashCaches(t *testing.T) {
 		c := e.cache(n)
 
 		// Do we get the right epoch length?
-		if n >= ecip1099Block && c.epochLength != epochLengthECIP1099 {
+		if c.epochLength != epl {
 			// Give the future epoch routine a chance to finish.
 			time.Sleep(1 * time.Second)
 
@@ -163,6 +163,16 @@ func TestEthashCaches(t *testing.T) {
 			}
 
 			t.Fatalf("Unexpected epoch length: %d", c.epochLength)
+		}
+
+		entries, _ := os.ReadDir(conf.CacheDir)
+		// We add +1 to CachesOnDisk because the future epoch cache is also created and can still
+		// be in-progress generating as a goroutine.
+		if len(entries) > conf.CachesOnDisk+1 {
+			for _, entry := range entries {
+				t.Logf(`  - %s`, entry.Name())
+			}
+			t.Fatalf("Too many cache files: %d", len(entries))
 		}
 	}
 }

--- a/consensus/ethash/ethash_test.go
+++ b/consensus/ethash/ethash_test.go
@@ -93,7 +93,6 @@ func TestEthashCaches(t *testing.T) {
 
 		// This is the tested function.
 		c := e.cache(n)
-		c.finalizer()
 
 		// Do we get the right epoch length?
 		if n >= ecip1099Block && c.epochLength != epochLengthECIP1099 {


### PR DESCRIPTION
Fixes #439 and #493. 

Please read commit messages for more context, but here's an overview:
- the bug was because of a bad `future item` in the in-memory lru cache
  + the post-ECIP1099 epochs caught up to pre-ECIP1099 epoch numbers and caused a bad cache hit
- cache files were named with `seed hashes`, which are hard to identify when epochs are not continuous
  + so I introduce a new filename scheme which includes epoch values and allows a scanner to identify and remove them as needed (avoiding a potential other bad-cache-hit scenario when seed hashes collide between pre- and post-ECIP1099 epochs)

This PR (and branch) uses #496 as a base. 

Here's Mordor passing 4_980_000 without issue:

```
INFO [08-30|09:17:28.928|core/headerchain.go:407]              Imported new block headers               count=256  elapsed=6.923ms     number=4,963,200 hash=581a33..ec7fda age=10mo1w3d                 
INFO [08-30|09:17:29.053|core/headerchain.go:407]              Imported new block headers               count=576  elapsed=124.596ms   number=4,963,776 hash=3aebf0..8eae21 age=10mo1w3d                 
INFO [08-30|09:17:29.246|core/blockchain.go:1214]              Imported new block receipts              count=190  elapsed=294.043ms   number=4,954,942 hash=489fd5..847757 age=10mo1w5d   size=63.34KiB 
INFO [08-30|09:17:29.534|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=281.566ms   number=4,956,990 hash=5d3baa..490a1f age=10mo1w4d   size=681.45KiB
INFO [08-30|09:17:29.826|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=286.437ms   number=4,959,038 hash=ff6d35..acb684 age=10mo1w4d   size=679.64KiB           
INFO [08-30|09:17:30.092|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=260.763ms   number=4,961,086 hash=9580f2..c100ae age=10mo1w4d   size=680.47KiB
INFO [08-30|09:17:30.364|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=265.470ms   number=4,963,134 hash=5bc83c..76c6e2 age=10mo1w3d   size=680.05KiB
INFO [08-30|09:17:30.614|core/blockchain.go:1214]              Imported new block receipts              count=642  elapsed=248.286ms   number=4,963,776 hash=3aebf0..8eae21 age=10mo1w3d   size=213.64KiB
INFO [08-30|09:17:30.872|core/headerchain.go:407]              Imported new block headers               count=576  elapsed=10.723ms    number=4,964,352 hash=e9a550..3151f5 age=10mo1w3d                 
INFO [08-30|09:17:31.144|core/blockchain.go:1214]              Imported new block receipts              count=61   elapsed=269.739ms   number=4,963,837 hash=96fa97..dbc97d age=10mo1w3d   size=20.24KiB
INFO [08-30|09:17:31.409|core/blockchain.go:1214]              Imported new block receipts              count=515  elapsed=263.677ms   number=4,964,352 hash=e9a550..3151f5 age=10mo1w3d   size=170.94KiB
INFO [08-30|09:17:31.495|core/headerchain.go:407]              Imported new block headers               count=192  elapsed=5.957ms     number=4,964,544 hash=1f3ff3..982112 age=10mo1w3d                 
INFO [08-30|09:17:31.756|core/blockchain.go:1214]              Imported new block receipts              count=192  elapsed=260.431ms   number=4,964,544 hash=1f3ff3..982112 age=10mo1w3d   size=63.62KiB 
INFO [08-30|09:17:34.519|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=79.619ms    number=4,966,592 hash=0d0324..14930c age=10mo1w3d                 
INFO [08-30|09:17:34.595|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=75.533ms    number=4,968,640 hash=cd1be2..1c9e07 age=10mo1w3d                 
INFO [08-30|09:17:34.670|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=73.257ms    number=4,970,688 hash=448753..9a8e81 age=10mo1w2d                 
INFO [08-30|09:17:34.756|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=86.058ms    number=4,972,736 hash=55a87e..45b1f4 age=10mo1w2d 
INFO [08-30|09:17:34.837|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=79.494ms    number=4,974,784 hash=9ffeef..a981dc age=10mo1w2d                 
INFO [08-30|09:17:34.900|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=62.553ms    number=4,976,832 hash=d38358..70604e age=10mo1w1d                 
INFO [08-30|09:17:34.955|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=54.026ms    number=4,978,880 hash=f4bac1..2c628f age=10mo1w1d                 
INFO [08-30|09:17:35.000|core/headerchain.go:407]              Imported new block headers               count=448  elapsed=44.670ms    number=4,979,328 hash=181f9d..e06a3c age=10mo1w1d                 
TRACE[08-30|09:17:35.009|consensus/ethash/ethash.go:217]       Evicted ethash cache                     epoch=81-60000                                                                                   
TRACE[08-30|09:17:35.009|consensus/ethash/ethash.go:257]       Requiring new future ethash cache        epoch=84                                                                         
DEBUG[08-30|09:17:35.010|consensus/ethash/ethash.go:368]       Failed to load old ethash cache          epoch=84       epochLength=60000 err="open /home/ia/.myethash-cache/cache-R23-84-a8784097a4d03c2d: no such file or directory"
INFO [08-30|09:17:35.042|core/headerchain.go:407]              Imported new block headers               count=768  elapsed=40.908ms    number=4,980,096 hash=07fb15..40f606 age=10mo1w1d                 
INFO [08-30|09:17:35.318|core/blockchain.go:1214]              Imported new block receipts              count=133  elapsed=264.958ms   number=4,964,677 hash=b17bcb..4807de age=10mo1w3d   size=44.12KiB 
INFO [08-30|09:17:35.593|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=269.068ms   number=4,966,725 hash=a3fdb5..6c8663 age=10mo1w3d   size=681.19KiB
INFO [08-30|09:17:35.877|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=276.736ms   number=4,968,773 hash=877640..3f5902 age=10mo1w3d   size=680.50KiB
DEBUG[08-30|09:17:35.929|consensus/ethash/algorithm.go:176]    Generated ethash verification cache      epoch=84       epochLength=60000 elapsed=915.834ms                                               
DEBUG[08-30|09:17:35.931|consensus/ethash/ethash.go:402]       Deleted ethash cache file                epoch=84       epochLength=60000 target.epoch=81 file=/home/ia/.myethash-cache/cache-R23-81-a92afa474bb50595
INFO [08-30|09:17:36.217|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=332.756ms   number=4,970,821 hash=62f824..981d8d age=10mo1w2d   size=683.95KiB
INFO [08-30|09:17:36.551|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=327.462ms   number=4,972,869 hash=98b78b..9cb63a age=10mo1w2d   size=680.60KiB
INFO [08-30|09:17:36.843|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=285.500ms   number=4,974,917 hash=b8060c..aae609 age=10mo1w2d   size=681.48KiB
INFO [08-30|09:17:37.198|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=347.532ms   number=4,976,965 hash=9bf489..ccf302 age=10mo1w1d   size=682.86KiB
INFO [08-30|09:17:37.502|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=190.267ms   number=4,982,144 hash=4a3de1..24b18d age=10mo1w1d
INFO [08-30|09:17:37.547|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=339.889ms   number=4,979,013 hash=61dbe4..b02121 age=10mo1w1d   size=680.57KiB
INFO [08-30|09:17:37.705|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=202.039ms   number=4,984,192 hash=66175c..b94432 age=10mo1w18h
INFO [08-30|09:17:37.907|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=201.292ms   number=4,986,240 hash=0132ca..c574f0 age=10mo1w11h
INFO [08-30|09:17:37.915|core/blockchain.go:1214]              Imported new block receipts              count=1083 elapsed=364.230ms   number=4,980,096 hash=07fb15..40f606 age=10mo1w1d   size=359.65KiB
INFO [08-30|09:17:38.225|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=317.752ms   number=4,988,288 hash=c34faa..ccab35 age=10mo1w4h
INFO [08-30|09:17:38.246|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=322.386ms   number=4,982,144 hash=4a3de1..24b18d age=10mo1w1d   size=676.31KiB
INFO [08-30|09:17:38.312|core/headerchain.go:407]              Imported new block headers               count=640  elapsed=86.325ms    number=4,988,928 hash=391503..500c35 age=10mo1w2h
INFO [08-30|09:17:38.521|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=265.879ms   number=4,984,192 hash=66175c..b94432 age=10mo1w18h  size=675.95KiB
INFO [08-30|09:17:38.896|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=366.782ms   number=4,986,240 hash=0132ca..c574f0 age=10mo1w11h  size=675.63KiB
INFO [08-30|09:17:39.201|core/blockchain.go:1214]              Imported new block receipts              count=2048 elapsed=298.374ms   number=4,988,288 hash=c34faa..ccab35 age=10mo1w4h   size=679.56KiB
INFO [08-30|09:17:39.504|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=133.771ms   number=4,990,976 hash=b371fd..c30a7d age=10mo6d18h
INFO [08-30|09:17:39.517|core/blockchain.go:1214]              Imported new block receipts              count=640  elapsed=313.894ms   number=4,988,928 hash=391503..500c35 age=10mo1w2h   size=211.31KiB
INFO [08-30|09:17:39.572|core/headerchain.go:407]              Imported new block headers               count=2048 elapsed=67.025ms    number=4,993,024 hash=61c843..9c49c7 age=10mo6d11h
```

Here's `--vmodule=consensus/*=6` logs during the same time context:
```
> tail -F geth.out |grep --line-buffered -E 'consensus' 
[...]
TRACE[08-30|09:16:52.950|consensus/ethash/ethash.go:257]       Requiring new future ethash cache        epoch=81                                                                                                                                                                                                                                 [0/15]
DEBUG[08-30|09:16:52.950|consensus/ethash/ethash.go:368]       Failed to load old ethash cache          epoch=81       epochLength=60000 err="open /home/ia/.myethash-cache/cache-R23-81-a92afa474bb50595: no such file or directory"
DEBUG[08-30|09:16:53.870|consensus/ethash/algorithm.go:176]    Generated ethash verification cache      epoch=81       epochLength=60000 elapsed=918.574ms
DEBUG[08-30|09:16:53.872|consensus/ethash/ethash.go:402]       Deleted ethash cache file                epoch=81       epochLength=60000 target.epoch=78 file=/home/ia/.myethash-cache/cache-R23-78-7b1e42ac7d205c8d
TRACE[08-30|09:17:04.349|consensus/ethash/ethash.go:217]       Evicted ethash cache                     epoch=79-60000
TRACE[08-30|09:17:04.350|consensus/ethash/ethash.go:257]       Requiring new future ethash cache        epoch=82
DEBUG[08-30|09:17:04.351|consensus/ethash/ethash.go:368]       Failed to load old ethash cache          epoch=82       epochLength=60000 err="open /home/ia/.myethash-cache/cache-R23-82-d5d85ca518675140: no such file or directory"
DEBUG[08-30|09:17:05.271|consensus/ethash/algorithm.go:176]    Generated ethash verification cache      epoch=82       epochLength=60000 elapsed=918.033ms
DEBUG[08-30|09:17:05.272|consensus/ethash/ethash.go:402]       Deleted ethash cache file                epoch=82       epochLength=60000 target.epoch=79 file=/home/ia/.myethash-cache/cache-R23-79-9d2e3fc27256471a
TRACE[08-30|09:17:17.520|consensus/ethash/ethash.go:217]       Evicted ethash cache                     epoch=80-60000
TRACE[08-30|09:17:17.520|consensus/ethash/ethash.go:257]       Requiring new future ethash cache        epoch=83
DEBUG[08-30|09:17:17.525|consensus/ethash/ethash.go:368]       Failed to load old ethash cache          epoch=83       epochLength=60000 err="open /home/ia/.myethash-cache/cache-R23-83-3aa8f28cac16bdd8: no such file or directory"
DEBUG[08-30|09:17:18.443|consensus/ethash/algorithm.go:176]    Generated ethash verification cache      epoch=83       epochLength=60000 elapsed=916.915ms
DEBUG[08-30|09:17:18.444|consensus/ethash/ethash.go:402]       Deleted ethash cache file                epoch=83       epochLength=60000 target.epoch=80 file=/home/ia/.myethash-cache/cache-R23-80-10fc9a2e5b65ea3f
TRACE[08-30|09:17:35.009|consensus/ethash/ethash.go:217]       Evicted ethash cache                     epoch=81-60000
TRACE[08-30|09:17:35.009|consensus/ethash/ethash.go:257]       Requiring new future ethash cache        epoch=84
DEBUG[08-30|09:17:35.010|consensus/ethash/ethash.go:368]       Failed to load old ethash cache          epoch=84       epochLength=60000 err="open /home/ia/.myethash-cache/cache-R23-84-a8784097a4d03c2d: no such file or directory"
DEBUG[08-30|09:17:35.929|consensus/ethash/algorithm.go:176]    Generated ethash verification cache      epoch=84       epochLength=60000 elapsed=915.834ms
DEBUG[08-30|09:17:35.931|consensus/ethash/ethash.go:402]       Deleted ethash cache file                epoch=84       epochLength=60000 target.epoch=81 file=/home/ia/.myethash-cache/cache-R23-81-a92afa474bb50595
TRACE[08-30|09:17:51.206|consensus/ethash/ethash.go:217]       Evicted ethash cache                     epoch=82-60000
TRACE[08-30|09:17:51.206|consensus/ethash/ethash.go:257]       Requiring new future ethash cache        epoch=85
DEBUG[08-30|09:17:51.206|consensus/ethash/ethash.go:368]       Failed to load old ethash cache          epoch=85       epochLength=60000 err="open /home/ia/.myethash-cache/cache-R23-85-4e99a30e99712c8c: no such file or directory"
DEBUG[08-30|09:17:52.130|consensus/ethash/algorithm.go:176]    Generated ethash verification cache      epoch=85       epochLength=60000 elapsed=922.632ms
DEBUG[08-30|09:17:52.131|consensus/ethash/ethash.go:402]       Deleted ethash cache file                epoch=85       epochLength=60000 target.epoch=82 file=/home/ia/.myethash-cache/cache-R23-82-d5d85ca518675140
```