### PR TITLE
.github/workflows: fixing c++/cmake issues w/r/t evmone, evmc tests

### DIFF
--- a/.github/workflows/evmc.yml
+++ b/.github/workflows/evmc.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Get dependencies
         run: |
           go get -v -t -d ./...
-          git config --global --add safe.directory /home/ia/go/src/github.com/ethereum/go-ethereum/tests/evm-benchmarks
-          git config --global --add safe.directory /home/ia/go/src/github.com/ethereum/go-ethereum/tests/testdata
-          git config --global --add safe.directory /home/ia/go/src/github.com/ethereum/go-ethereum/tests/testdata/LegacyTests
+          git config --global --add safe.directory $(pwd)/tests/evm-benchmarks
+          git config --global --add safe.directory $(pwd)/tests/testdata
+          git config --global --add safe.directory $(pwd)/tests/testdata/LegacyTests
           git submodule update --init --recursive
           export GOBIN=${HOME}/go/bin
           mkdir -p "${GOBIN}"

--- a/.github/workflows/evmc.yml
+++ b/.github/workflows/evmc.yml
@@ -22,9 +22,31 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Install cmake
+        run: |
+          sudo apt-get update -y
+          sudo apt-get upgrade -y
+          sudo apt-get install -y cmake
+          cmake --version
+
+      - name: Install necessary GLIBCXX version
+        run: |
+          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-9 g++-9
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
+          g++ --version
+          gcc --version     
+          strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+
       - name: Get dependencies
         run: |
           go get -v -t -d ./...
+          git config --global --add safe.directory /home/ia/go/src/github.com/ethereum/go-ethereum/tests/evm-benchmarks
+          git config --global --add safe.directory /home/ia/go/src/github.com/ethereum/go-ethereum/tests/testdata
+          git config --global --add safe.directory /home/ia/go/src/github.com/ethereum/go-ethereum/tests/testdata/LegacyTests
           git submodule update --init --recursive
           export GOBIN=${HOME}/go/bin
           mkdir -p "${GOBIN}"


### PR DESCRIPTION
The command 'make test-evmc' complains about a GLIBCXX version incompatibility (missing 3.4.29).

This issue has been shown resolved by the Actions CI run here: https://github.com/meowsbits/core-geth/actions/runs/3429882085/jobs/5716103415 The run ultimately fails, but it fails because the tests fail, while the evmone .so is used appropriately.

Full context of the error follows.

```
panic: EVMC loading error: /lib/x86_64-linux-gnu/libstdc++.so.6: version GLIBCXX_3.4.29 not found, required by /home/ia/go/src/github.com/ethereum/go-ethereum/build/_workspace/evmone/lib/libevmone.so

 goroutine 1 [running]:
 github.com/ethereum/go-ethereum/core/vm.initEVMC(0x11e4e0?, {0x7ffc235f574c?, 0xc0001361c0?})
       /home/ia/go/src/github.com/ethereum/go-ethereum/core/vm/evmc.go:83 +0x605
 github.com/ethereum/go-ethereum/core/vm.InitEVMCEVM({0x7ffc235f574c, 0x58})
       /home/ia/go/src/github.com/ethereum/go-ethereum/core/vm/evmc.go:60 +0xd0
 github.com/ethereum/go-ethereum/tests.TestMain(0xffffffffffffffff?)
       /home/ia/go/src/github.com/ethereum/go-ethereum/tests/init_test.go:50 +0xec
 main.main()
       _testmain.go:77 +0x1d3
 FAIL  github.com/ethereum/go-ethereum/tests   0.014s
 FAIL
 make: *** [Makefile:57: test-evmc] Error 1
```

See also here: https://github.com/etclabscore/core-geth/actions/runs/3414467176/jobs/5682462570#step:5:482

Date: 2022-11-09 07:44:38-08:00
Signed-off-by: meows <b5c6@protonmail.com>