### PR TITLE
replace ioutil with os,io 

### DIFF
--- a/cmd/echainspec/util.go
+++ b/cmd/echainspec/util.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -15,9 +15,9 @@ import (
 
 func readInputData(ctx *cli.Context) ([]byte, error) {
 	if !ctx.GlobalIsSet(fileInFlag.Name) {
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	}
-	return ioutil.ReadFile(ctx.GlobalString(fileInFlag.Name))
+	return os.ReadFile(ctx.GlobalString(fileInFlag.Name))
 }
 
 func unmarshalChainSpec(format string, data []byte) (conf ctypes.Configurator, err error) {

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"net/http"
@@ -184,7 +183,7 @@ func parseChainFlags() (gs *genesisT.Genesis, bs string, netid uint64) {
 
 	// allow overrides
 	if *genesisFlag != "" {
-		blob, err := ioutil.ReadFile(*genesisFlag)
+		blob, err := os.ReadFile(*genesisFlag)
 		if err != nil {
 			log.Crit("Failed to read genesis block contents", "genesis", *genesisFlag, "err", err)
 		}
@@ -414,7 +413,7 @@ func main() {
 
 	keystorePath := filepath.Join(faucetDirFromChainIndicators(chainID, genesisHash), "keys")
 	ks := keystore.NewKeyStore(keystorePath, keystore.StandardScryptN, keystore.StandardScryptP)
-	if blob, err = ioutil.ReadFile(*accJSONFlag); err != nil {
+	if blob, err = os.ReadFile(*accJSONFlag); err != nil {
 		log.Crit("Failed to read account key contents", "file", *accJSONFlag, "err", err)
 	}
 	acc, err := ks.Import(blob, pass, pass)

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -179,7 +178,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 
 	genesis := new(genesisT.Genesis)
-	bs, err := ioutil.ReadFile(genesisPath)
+	bs, err := os.ReadFile(genesisPath)
 	if err != nil {
 		utils.Fatalf("Failed to read genesis file: %v", err)
 	}

--- a/eth/tracers/internal/tracetest/calltrace_parity_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_parity_test.go
@@ -3,8 +3,8 @@ package tracetest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -51,7 +51,7 @@ type callTracerParityTest struct {
 
 func callTracerParityTestRunner(tracerName string, filename string, dirPath string, t testing.TB) error {
 	// Call tracer test found, read if from disk
-	blob, err := ioutil.ReadFile(filepath.Join("testdata", dirPath, filename))
+	blob, err := os.ReadFile(filepath.Join("testdata", dirPath, filename))
 	if err != nil {
 		return fmt.Errorf("failed to read testcase: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestCallTracerParityNative(t *testing.T) {
 }
 
 func testCallTracerParity(tracerName string, dirPath string, t *testing.T) {
-	files, err := ioutil.ReadDir(filepath.Join("testdata", dirPath))
+	files, err := os.ReadDir(filepath.Join("testdata", dirPath))
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
 	}
@@ -208,7 +208,7 @@ type stateDiffTest struct {
 
 func stateDiffTracerTestRunner(tracerName string, filename string, dirPath string, t testing.TB) error {
 	// Call tracer test found, read if from disk
-	blob, err := ioutil.ReadFile(filepath.Join("testdata", dirPath, filename))
+	blob, err := os.ReadFile(filepath.Join("testdata", dirPath, filename))
 	if err != nil {
 		return fmt.Errorf("failed to read testcase: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestStateDiffTracerNative(t *testing.T) {
 // TestStateDiffTracer Iterates over all the input-output datasets in the state diff tracer test harness and
 // runs the JavaScript tracers against them.
 func testStateDiffTracer(tracerName string, dirPath string, t *testing.T) {
-	files, err := ioutil.ReadDir(filepath.Join("testdata", dirPath))
+	files, err := os.ReadDir(filepath.Join("testdata", dirPath))
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
 	}

--- a/ethclient/docsgen_test.go
+++ b/ethclient/docsgen_test.go
@@ -3,7 +3,6 @@ package ethclient
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -49,7 +48,7 @@ func TestRPCDiscover_BuildStatic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile("../build/static/openrpc.json", data, os.ModePerm)
+	err = os.WriteFile("../build/static/openrpc.json", data, os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/configurator_test.go
+++ b/integration/configurator_test.go
@@ -18,8 +18,8 @@ package integration
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -176,7 +176,7 @@ func TestEquivalent_ReadParity(t *testing.T) {
 		a := tests.Forks[k]
 
 		b := &parity.ParityChainSpec{}
-		bs, err := ioutil.ReadFile(filepath.Join(parityP, v))
+		bs, err := os.ReadFile(filepath.Join(parityP, v))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestParityGeneses(t *testing.T) {
 	for _, tt := range testes {
 		p := filepath.Join("..", "params", "parity.json.d", tt.filename)
 		pspec := &parity.ParityChainSpec{}
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -328,7 +327,7 @@ func TestOpenRPCMetaSchemaSpecLatest(t *testing.T) {
 	}
 
 	localJSONFilePath := "./testdata/open-rpc-meta-schema-1.14.0.json"
-	localJSONFile, err := ioutil.ReadFile(localJSONFilePath)
+	localJSONFile, err := os.ReadFile(localJSONFilePath)
 	if err != nil {
 		t.Fatalf("failed to load local spec JSON file: %v", err)
 	}

--- a/params/confp/generic/generic_test.go
+++ b/params/confp/generic/generic_test.go
@@ -2,8 +2,8 @@ package generic
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -39,7 +39,7 @@ func TestUnmarshalChainConfigurator(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		b, err := ioutil.ReadFile(c.file)
+		b, err := os.ReadFile(c.file)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -250,19 +250,19 @@ func TestUnmarshalChainConfigurator2(t *testing.T) {
 			wantType: reflect.TypeOf(&coregeth.CoreGethChainConfig{}),
 		},
 		// FIXME
-		//{
+		// {
 		//	versionid: "latest",
 		//	raw: func() string {
 		//		b, _ := json.MarshalIndent(params.ClassicChainConfig, "", "    ")
 		//		return string(b)
 		//	}(),
 		//	wantType: reflect.TypeOf(&multigeth.CoreGethChainConfig{}),
-		//},
+		// },
 	}
 
 	head := uint64(10_000_000)
 
-	//outer:
+	// outer:
 	for i := 0; i < len(cases); i++ {
 		for j := 0; j < len(cases); j++ {
 			if j >= i {

--- a/params/confp/internal/convert_test.go
+++ b/params/confp/internal/convert_test.go
@@ -19,8 +19,8 @@ package convert_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -36,7 +36,7 @@ import (
 )
 
 func mustOpenF(t *testing.T, fabbrev string, into interface{}) {
-	b, err := ioutil.ReadFile(filepath.Join("..", "testdata", fmt.Sprintf("stureby_%s.json", fabbrev)))
+	b, err := os.ReadFile(filepath.Join("..", "testdata", fmt.Sprintf("stureby_%s.json", fabbrev)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/params/confp/tconvert/aleth_test.go
+++ b/params/confp/tconvert/aleth_test.go
@@ -18,7 +18,7 @@ package tconvert
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +31,7 @@ import (
 // Tests the go-ethereum to Aleth chainspec conversion for the Stureby testnet.
 func TestAlethSturebyConverter(t *testing.T) {
 	// Read GETH genesis type.
-	blob, err := ioutil.ReadFile(filepath.Join("..", "testdata", "stureby_geth.json"))
+	blob, err := os.ReadFile(filepath.Join("..", "testdata", "stureby_geth.json"))
 	if err != nil {
 		t.Fatalf("could not read file: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestAlethSturebyConverter(t *testing.T) {
 	}
 
 	// Read the aleth JSON spec.
-	expBlob, err := ioutil.ReadFile(filepath.Join("..", "testdata", "stureby_aleth.json"))
+	expBlob, err := os.ReadFile(filepath.Join("..", "testdata", "stureby_aleth.json"))
 	if err != nil {
 		t.Fatalf("could not read file: %v", err)
 	}

--- a/params/types/parity/parity_configurator_test.go
+++ b/params/types/parity/parity_configurator_test.go
@@ -18,7 +18,7 @@ package parity
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/math"
@@ -62,7 +62,7 @@ func TestParityChainSpec_GetSetUint64(t *testing.T) {
 
 func TestParityChainSpec_GetEIP2537(t *testing.T) {
 	specFile := "../../parity.json.d/foundation.json"
-	b, err := ioutil.ReadFile(specFile)
+	b, err := os.ReadFile(specFile)
 	if err != nil {
 		t.Fatalf("read file: %v", err)
 	}

--- a/params/types/parity/parity_test.go
+++ b/params/types/parity/parity_test.go
@@ -18,7 +18,6 @@ package parity
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,7 +97,7 @@ func TestParityChainSpec_UnmarshalJSON(t *testing.T) {
 			return nil
 		}
 		t.Run(info.Name(), func(t *testing.T) {
-			b, err := ioutil.ReadFile(path)
+			b, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tests/difficulty_mgen_test.go
+++ b/tests/difficulty_mgen_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -103,7 +102,7 @@ func TestDifficultyTestConfigGen(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(specPath, j, os.ModePerm)
+		err = os.WriteFile(specPath, j, os.ModePerm)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -131,7 +130,7 @@ func TestDifficultyTestConfigGen(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(specPath, j, os.ModePerm)
+		err = os.WriteFile(specPath, j, os.ModePerm)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -157,7 +156,7 @@ func TestDifficultyGen(t *testing.T) {
 	}
 
 	// Truncate/touch output file.
-	err = ioutil.WriteFile(outNDJSONFile, []byte{}, os.ModePerm)
+	err = os.WriteFile(outNDJSONFile, []byte{}, os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +196,7 @@ func TestDifficultyGen(t *testing.T) {
 	}
 
 	mustSha1SumForFile := func(filePath string) []byte {
-		b, err := ioutil.ReadFile(filePath)
+		b, err := os.ReadFile(filePath)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/params.go
+++ b/tests/params.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -113,7 +112,7 @@ func readJSONFromFile(name string, value interface{}) (sha1sum []byte, err error
 	} else {
 		fi.Close()
 	}
-	b, err := ioutil.ReadFile(name)
+	b, err := os.ReadFile(name)
 	if err != nil {
 		panic(fmt.Sprintf("%s err: %s\n%s", name, err, b))
 	}
@@ -160,7 +159,7 @@ func writeDifficultyConfigFileParity(conf ctypes.ChainConfigurator, forkName str
 		return "", [20]byte{}, err
 	}
 
-	err = ioutil.WriteFile(filepath.Join("..", "params", "parity.json.d", specFilepath), b, os.ModePerm)
+	err = os.WriteFile(filepath.Join("..", "params", "parity.json.d", specFilepath), b, os.ModePerm)
 	if err != nil {
 		return "", [20]byte{}, err
 	}
@@ -291,7 +290,7 @@ func init() {
 				config = pspec
 				b, _ := json.MarshalIndent(pspec, "", "    ")
 				writePath := filepath.Join(paritySpecsDir, v)
-				err := ioutil.WriteFile(writePath, b, os.ModePerm)
+				err := os.WriteFile(writePath, b, os.ModePerm)
 				if err != nil {
 					panic(fmt.Sprintf("failed to write chainspec; wd: %s, config: %v/file: %v", wd, k, writePath))
 				}

--- a/tests/state_mgen_test.go
+++ b/tests/state_mgen_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -118,7 +117,7 @@ func TestGenStateAll(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = ioutil.WriteFile(fmt.Sprintf("%s_configs.json", dir), b, os.ModePerm)
+		err = os.WriteFile(fmt.Sprintf("%s_configs.json", dir), b, os.ModePerm)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -175,7 +174,7 @@ func (tm *testMatcherGen) testWriteTest(t *testing.T, name string, test *StateTe
 	// Note that parallelism can cause greasy bugs around file during read/write which is why
 	// we use a temporary file instead of immediately overwriting the canonical file in the first place;
 	// for example, I saw regular encoding errors without this pattern.
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "geth-state-test-generation")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "geth-state-test-generation")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +403,7 @@ func TestGenStateCoreGethConfigs(t *testing.T) {
 					coregethSpecsDir,
 					strcase.ToSnake(subtest.Fork)+"_test.json",
 				)
-				err = ioutil.WriteFile(filename, b, os.ModePerm)
+				err = os.WriteFile(filename, b, os.ModePerm)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
`make lint` complains that as of Go 1.16, `ioutil` is deprecated and is to be replace by `os` and `io`.

These errors look like this:

```
make lint                                                                                                                                                                                      
env GO111MODULE=on go run build/ci.go lint                                                                                                                                                     
build/cache/golangci-lint-1.46.2-linux-amd64.tar.gz is up-to-date                                                                                                                              
>>> build/cache/golangci-lint-1.46.2-linux-amd64/golangci-lint run --timeout 3m0s --config .golangci.yml ./...
tests/params.go:23:2: SA1019: package io/ioutil is deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)                                                                                                               
        "io/ioutil"                                                                                                                                                                            
        ^                                                                                                                                                                                      
tests/difficulty_mgen_test.go:23:2: SA1019: package io/ioutil is deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"                                                                               
        ^                                                                                                                                                                                      
tests/state_mgen_test.go:23:2: SA1019: package io/ioutil is deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be 
preferred in new code. See the specific function documentation for details. (staticcheck)                                                                                                      
        "io/ioutil"                                                                                                                                                                            
        ^                                                                                                                                                                                      
util.go:47: exit status 1                                                                                                                                                                      
exit status 1                                                                                                                                                                                  
Makefile:108: recipe for target 'lint' failed                                  
make: *** [lint] Error 1              
```