### PR TITLE
.github/workflows: benchstat@latest no longer has --geomean option

### DIFF
--- a/.github/workflows/bench-core.yml
+++ b/.github/workflows/bench-core.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: "Analyze Results [COMPRESSED]"
         run: |
-          benchstat --geomean go-ethereum.txt core-geth.txt
+          benchstat go-ethereum.txt core-geth.txt
 
       - name: "Analyze Results [RAW DELTA]"
         run: |
-          benchstat --geomean --delta-test=none go-ethereum.txt core-geth.txt
+          benchstat --delta-test=none go-ethereum.txt core-geth.txt

--- a/.github/workflows/bench-trie.yml
+++ b/.github/workflows/bench-trie.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: "Analyze Results [COMPRESSED]"
         run: |
-          benchstat --geomean go-ethereum.txt core-geth.txt
+          benchstat go-ethereum.txt core-geth.txt
 
       - name: "Analyze Results [RAW DELTA]"
         run: |
-          benchstat --geomean --delta-test=none go-ethereum.txt core-geth.txt
+          benchstat --delta-test=none go-ethereum.txt core-geth.txt

--- a/.github/workflows/bench-vm.yml
+++ b/.github/workflows/bench-vm.yml
@@ -98,8 +98,8 @@ jobs:
 
       - name: "Analyze Results [COMPRESSED]"
         run: |
-          benchstat --geomean go-ethereum_compress.txt core-geth_compress.txt
+          benchstat go-ethereum_compress.txt core-geth_compress.txt
 
       - name: "Analyze Results [RAW DELTA]"
         run: |
-          benchstat --geomean --delta-test=none go-ethereum.txt core-geth.txt
+          benchstat --delta-test=none go-ethereum.txt core-geth.txt


### PR DESCRIPTION
So remove it. It was nice-to-have, but unnecessary and little used.
Will fix https://github.com/etclabscore/core-geth/actions/runs/3988067039/jobs/6838805330

Date: 2023-01-23 08:05:52-08:00
Signed-off-by: meows <b5c6@protonmail.com>