### PR TITLE
Ci/fix benchstat

### DIFF
--- a/.github/workflows/bench-core.yml
+++ b/.github/workflows/bench-core.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'ethereum/go-ethereum'
-          ref: 'v1.9.25'
+          ref: 'v1.10.26'
 
       - name: Benchmark ethereum/go-ethereum
         id: bench

--- a/.github/workflows/bench-core.yml
+++ b/.github/workflows/bench-core.yml
@@ -91,4 +91,4 @@ jobs:
 
       - name: "Analyze Results [RAW DELTA]"
         run: |
-          benchstat --delta-test=none go-ethereum.txt core-geth.txt
+          benchstat go-ethereum.txt core-geth.txt

--- a/.github/workflows/bench-trie.yml
+++ b/.github/workflows/bench-trie.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'ethereum/go-ethereum'
-          ref: 'v1.9.25'
+          ref: 'v1.10.26'
 
       - name: Benchmark ethereum/go-ethereum
         id: bench

--- a/.github/workflows/bench-trie.yml
+++ b/.github/workflows/bench-trie.yml
@@ -91,4 +91,4 @@ jobs:
 
       - name: "Analyze Results [RAW DELTA]"
         run: |
-          benchstat --delta-test=none go-ethereum.txt core-geth.txt
+          benchstat go-ethereum.txt core-geth.txt

--- a/.github/workflows/bench-vm.yml
+++ b/.github/workflows/bench-vm.yml
@@ -102,4 +102,4 @@ jobs:
 
       - name: "Analyze Results [RAW DELTA]"
         run: |
-          benchstat --delta-test=none go-ethereum.txt core-geth.txt
+          benchstat go-ethereum.txt core-geth.txt

--- a/.github/workflows/bench-vm.yml
+++ b/.github/workflows/bench-vm.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           git remote add foundation https://github.com/ethereum/go-ethereum.git
           git fetch foundation
-          git checkout v1.9.25
+          git checkout v1.10.26
           # git submodule update
           git checkout $GITHUB_SHA -- tests/vm_bench_test.go
           go test -short ./tests -count 1 -p 1 -timeout 60m -run NONE -bench=VM -v |& tee go-ethereum.txt


### PR DESCRIPTION
- Fixes `benchstat --delta-test=none` (flag does not exist anymore) by removing it
  + https://github.com/etclabscore/core-geth/actions/runs/3988261148/jobs/6839355366
- Bumps compared-against ethereum/go-ethereum version from v1.9.25 to v1.10.26