### PR TITLE
eth: fix race condition in eth/sync tests

### DIFF
--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -219,7 +219,8 @@ func TestArtificialFinalityFeatureEnablingDisabling_AbleDisable(t *testing.T) {
 		t.Fatalf("sync failed: %v", err)
 	}
 
-	b.handler.chainSync.forced = true
+	atomic.StoreUint32(&b.handler.chainSync.forced, 1)
+
 	next := b.handler.chainSync.nextSyncOp()
 	if next != nil {
 		t.Fatal("non-nil next sync op")
@@ -235,7 +236,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_AbleDisable(t *testing.T) {
 	minArtificialFinalityPeers = oMinAFPeers
 
 	// Next sync op will unset AF because manager only has 1 peer.
-	b.handler.chainSync.forced = true
+	atomic.StoreUint32(&b.handler.chainSync.forced, 1)
 	next = b.handler.chainSync.nextSyncOp()
 	if next != nil {
 		t.Fatal("non-nil next sync op")
@@ -306,7 +307,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 		t.Fatalf("sync failed: %v", err)
 	}
 
-	b.handler.chainSync.forced = true
+	atomic.StoreUint32(&b.handler.chainSync.forced, 1)
 	next := b.handler.chainSync.nextSyncOp()
 
 	// Revert safety condition overrides to default values.
@@ -324,7 +325,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 	}
 
 	// Next sync op will unset AF because manager only has 1 peer.
-	b.handler.chainSync.forced = true
+	atomic.StoreUint32(&b.handler.chainSync.forced, 1)
 	next = b.handler.chainSync.nextSyncOp()
 	if next != nil {
 		t.Fatal("non-nil next sync op")
@@ -393,7 +394,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_StaleHead(t *testing.T) {
 		t.Fatalf("sync failed: %v", err)
 	}
 
-	b.handler.chainSync.forced = true
+	atomic.StoreUint32(&b.handler.chainSync.forced, 1)
 	next := b.handler.chainSync.nextSyncOp()
 
 	// Revert safety condition overrides to default values.

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -166,12 +166,12 @@ func TestArtificialFinalityFeatureEnablingDisabling_AbleDisable(t *testing.T) {
 	// Its important to do this before starting the syncer because
 	// of a potential data race with the minArtificialFinalityPeers value.
 	// This value does not (should not) change during geth runtime.
-	oMinAFPeers := minArtificialFinalityPeers
+	oMinAFPeers := atomic.LoadUint32(&minArtificialFinalityPeers)
 	defer func() {
 		// Clean up after, resetting global default to original value.
-		minArtificialFinalityPeers = oMinAFPeers
+		atomic.StoreUint32(&minArtificialFinalityPeers, oMinAFPeers)
 	}()
-	minArtificialFinalityPeers = 1
+	atomic.StoreUint32(&minArtificialFinalityPeers, 1)
 
 	maxBlocksCreated := 1024
 	genFunc := blockGenContemporaryTime(int64(maxBlocksCreated))
@@ -233,7 +233,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_AbleDisable(t *testing.T) {
 	}
 
 	// Set the value back to default (more than 1).
-	minArtificialFinalityPeers = oMinAFPeers
+	atomic.StoreUint32(&minArtificialFinalityPeers, oMinAFPeers)
 
 	// Next sync op will unset AF because manager only has 1 peer.
 	atomic.StoreUint32(&b.handler.chainSync.forced, 1)
@@ -256,12 +256,12 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 	// Its important to do this before starting the syncer because
 	// of a potential data race with the minArtificialFinalityPeers value.
 	// This value does not (should not) change during geth runtime.
-	oMinAFPeers := minArtificialFinalityPeers
+	oMinAFPeers := atomic.LoadUint32(&minArtificialFinalityPeers)
 	defer func() {
 		// Clean up after, resetting global default to original value.
-		minArtificialFinalityPeers = oMinAFPeers
+		atomic.StoreUint32(&minArtificialFinalityPeers, oMinAFPeers)
 	}()
-	minArtificialFinalityPeers = 1
+	atomic.StoreUint32(&minArtificialFinalityPeers, 1)
 
 	maxBlocksCreated := 1024
 	genFunc := blockGenContemporaryTime(int64(maxBlocksCreated))
@@ -312,7 +312,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 
 	// Revert safety condition overrides to default values.
 	// Set the value back to default (more than 1).
-	minArtificialFinalityPeers = oMinAFPeers
+	atomic.StoreUint32(&minArtificialFinalityPeers, oMinAFPeers)
 
 	if next != nil {
 		t.Fatal("non-nil next sync op")
@@ -350,12 +350,12 @@ func TestArtificialFinalityFeatureEnablingDisabling_StaleHead(t *testing.T) {
 	// Its important to do this before starting the syncer because
 	// of a potential data race with the minArtificialFinalityPeers value.
 	// This value does not (should not) change during geth runtime.
-	oMinAFPeers := minArtificialFinalityPeers
+	oMinAFPeers := atomic.LoadUint32(&minArtificialFinalityPeers)
 	defer func() {
 		// Clean up after, resetting global default to original value.
-		minArtificialFinalityPeers = oMinAFPeers
+		atomic.StoreUint32(&minArtificialFinalityPeers, oMinAFPeers)
 	}()
-	minArtificialFinalityPeers = 1
+	atomic.StoreUint32(&minArtificialFinalityPeers, 1)
 
 	maxBlocksCreated := 1024
 
@@ -399,7 +399,7 @@ func TestArtificialFinalityFeatureEnablingDisabling_StaleHead(t *testing.T) {
 
 	// Revert safety condition overrides to default values.
 	// Set the value back to default (more than 1).
-	minArtificialFinalityPeers = oMinAFPeers
+	atomic.StoreUint32(&minArtificialFinalityPeers, oMinAFPeers)
 
 	if next != nil {
 		t.Fatal("non-nil next sync op")

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -158,7 +158,21 @@ func testSnapSyncDisabling(t *testing.T, ethVer uint, snapVer uint) {
 	}
 }
 
-func TestArtificialFinalityFeatureEnablingDisabling(t *testing.T) {
+func TestArtificialFinalityFeatureEnablingDisabling_AbleDisable(t *testing.T) {
+	// Tweak the hardcoded minArtificialFinalityPeers value
+	// before anything else (and establish its reassignment to original value).
+	// Lowering the value from the default is only done to save the boilerplate of
+	// setting up 5 peers instead of 1.
+	// Its important to do this before starting the syncer because
+	// of a potential data race with the minArtificialFinalityPeers value.
+	// This value does not (should not) change during geth runtime.
+	oMinAFPeers := minArtificialFinalityPeers
+	defer func() {
+		// Clean up after, resetting global default to original value.
+		minArtificialFinalityPeers = oMinAFPeers
+	}()
+	minArtificialFinalityPeers = 1
+
 	maxBlocksCreated := 1024
 	genFunc := blockGenContemporaryTime(int64(maxBlocksCreated))
 
@@ -171,13 +185,6 @@ func TestArtificialFinalityFeatureEnablingDisabling(t *testing.T) {
 
 	one := uint64(1)
 	a.chain.Config().SetECBP1100Transition(&one)
-
-	oMinAFPeers := minArtificialFinalityPeers
-	defer func() {
-		// Clean up after, resetting global default to original value.
-		minArtificialFinalityPeers = oMinAFPeers
-	}()
-	minArtificialFinalityPeers = 1
 
 	// Create a full protocol manager, check that fast sync gets disabled
 	b := newTestHandlerWithBlocksWithOpts(0, downloader.FullSync, genFunc)
@@ -241,6 +248,20 @@ func TestArtificialFinalityFeatureEnablingDisabling(t *testing.T) {
 // TestArtificialFinalityFeatureEnablingDisabling_NoDisable tests that when the nodisable override
 // is in place (see NOTE1 below), AF is not disabled at the min peer floor.
 func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
+	// Tweak the hardcoded minArtificialFinalityPeers value
+	// before anything else (and establish its reassignment to original value).
+	// Lowering the value from the default is only done to save the boilerplate of
+	// setting up 5 peers instead of 1.
+	// Its important to do this before starting the syncer because
+	// of a potential data race with the minArtificialFinalityPeers value.
+	// This value does not (should not) change during geth runtime.
+	oMinAFPeers := minArtificialFinalityPeers
+	defer func() {
+		// Clean up after, resetting global default to original value.
+		minArtificialFinalityPeers = oMinAFPeers
+	}()
+	minArtificialFinalityPeers = 1
+
 	maxBlocksCreated := 1024
 	genFunc := blockGenContemporaryTime(int64(maxBlocksCreated))
 
@@ -250,13 +271,6 @@ func TestArtificialFinalityFeatureEnablingDisabling_NoDisable(t *testing.T) {
 
 	one := uint64(1)
 	a.chain.Config().SetECBP1100Transition(&one)
-
-	oMinAFPeers := minArtificialFinalityPeers
-	defer func() {
-		// Clean up after, resetting global default to original value.
-		minArtificialFinalityPeers = oMinAFPeers
-	}()
-	minArtificialFinalityPeers = 1
 
 	// Create a full protocol manager, check that fast sync gets disabled
 	b := newTestHandlerWithBlocksWithOpts(0, downloader.FullSync, genFunc)
@@ -328,6 +342,20 @@ and the number of peers 'a' is connected with being only 1.)`)
 // be very old (far exceeding the auto-disable stale limit).
 // In this case, AF features should NOT be enabled.
 func TestArtificialFinalityFeatureEnablingDisabling_StaleHead(t *testing.T) {
+	// Tweak the hardcoded minArtificialFinalityPeers value
+	// before anything else (and establish its reassignment to original value).
+	// Lowering the value from the default is only done to save the boilerplate of
+	// setting up 5 peers instead of 1.
+	// Its important to do this before starting the syncer because
+	// of a potential data race with the minArtificialFinalityPeers value.
+	// This value does not (should not) change during geth runtime.
+	oMinAFPeers := minArtificialFinalityPeers
+	defer func() {
+		// Clean up after, resetting global default to original value.
+		minArtificialFinalityPeers = oMinAFPeers
+	}()
+	minArtificialFinalityPeers = 1
+
 	maxBlocksCreated := 1024
 
 	// Create a full protocol manager, check that fast sync gets disabled
@@ -335,13 +363,6 @@ func TestArtificialFinalityFeatureEnablingDisabling_StaleHead(t *testing.T) {
 	defer a.close()
 	one := uint64(1)
 	a.chain.Config().SetECBP1100Transition(&one)
-
-	oMinAFPeers := minArtificialFinalityPeers
-	defer func() {
-		// Clean up after, resetting global default to original value.
-		minArtificialFinalityPeers = oMinAFPeers
-	}()
-	minArtificialFinalityPeers = 1
 
 	// Create a full protocol manager, check that fast sync gets disabled
 	b := newTestHandlerWithBlocksWithOpts(0, downloader.FullSync, nil)


### PR DESCRIPTION
Fixes https://github.com/etclabscore/core-geth/issues/521

The race was discoverable with
`go test -race ./eth`
or under 'slow' machine conditions, eg. GOMAXPROCS=1 and/or a 'slower' machine.

The race was around the `minArtificialFinalityPeers` value, which was both
- assigned in (during) the tests, and
- checked in the nextSyncOp function

and the order of those uses was nondeterministic.

This patch resolves the issue by moving
the adhoc and temporary re-assignment of that
package-wide value to the start of the tests,
before any go routines for peer handling
or sync protocol are fired off.

Note that the real-clock timeouts in these
tests can still (invariantly) cause spurious test failures
under 'slow' conditions (see their 250ms sleeps).

This invariant limitation (seen in the upstream-identical tests `TestSnapSyncDisabling6[6|7]`) can be reproduced on my computer with:

```sh
for i in 1 0
do env GOMAXPROCS=$i go test -count 1 -run SnapSyncDisabling ./eth >/dev/null 2>&1 && echo ok || echo failed
done
failed
ok
```

---

Reviewers can test the efficacy of this patch with

```
$ go test -race ./eth
ok      github.com/ethereum/go-ethereum/eth     38.158s
```