### PR TITLE
[WIP] fix high CPU use 

### DIFF
--- a/core/tx_cacher.go
+++ b/core/tx_cacher.go
@@ -60,16 +60,9 @@ func newTxSenderCacher(threads int) *txSenderCacher {
 // cache is an infinite loop, caching transaction senders from various forms of
 // data structures.
 func (cacher *txSenderCacher) cache() {
-	for {
-		select {
-		case task := <-cacher.tasks:
-			for i := 0; i < len(task.txs); i += task.inc {
-				types.Sender(task.signer, task.txs[i])
-			}
-		default:
-			if cacher.tasks == nil {
-				return
-			}
+	for task := range cacher.tasks {
+		for i := 0; i < len(task.txs); i += task.inc {
+			types.Sender(task.signer, task.txs[i])
 		}
 	}
 }


### PR DESCRIPTION
Intended to resolve #524. 

- Revert "core: maybe fix panic"
  This reverts commit 83fb902128c1d88b745450f4d90cb0d77e90a034.

Below, the `go tool pprof` results for `top`. 

```
ia@ianuc:~/Downloads$ go tool pprof profile\(2\)                                                                                                                                                                
File: geth                                                                                                                                                                                                      
Build ID: 2a4f22ee8855c29f44a2a89684537cf6e595fa37                                                                                                                                                              
Type: cpu                                                                                                                                                                                                       
Time: Feb 6, 2023 at 11:07am (PST)                                                                                                                                                                              
Duration: 5.18s, Total samples = 57.12s (1102.14%)                                                                                                                                                              
Entering interactive mode (type "help" for commands, "o" for options)                                                                                                                                           
(pprof) top                                                                                                                                                                                                     
Showing nodes accounting for 57.04s, 99.86% of 57.12s total                                                                                                                                                     Dropped 34 nodes (cum <= 0.29s)                                                                         
      flat  flat%   sum%        cum   cum%                                                                                                                                                                      
    21.40s 37.46% 37.46%     57.05s 99.88%  github.com/ethereum/go-ethereum/core.(*txSenderCacher).cache                                                                                                        
    15.99s 27.99% 65.46%     21.36s 37.39%  runtime.chanrecv                                                                                                                                                    
    14.28s 25.00% 90.46%     35.64s 62.39%  runtime.selectnbrecv                                                                                                                                                
     5.37s  9.40% 99.86%      5.37s  9.40%  runtime.empty (inline) 
```

![image](https://user-images.githubusercontent.com/45600330/217069198-f7da33bd-88d9-4c5e-970c-41f761211cc3.png)


