### PR TITLE
Release/v1.12.10

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 10       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 11         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 12         // Minor version component of the current release
-	VersionPatch = 10         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 12       // Minor version component of the current release
+	VersionPatch = 10       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
This is a hotfix release for the previous v1.12.9, which used too much CPU because the `txSenderCacher` was misbehaving.