### PR TITLE
Jenkinsfile: bump go version 1.18.3 to 1.20.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,8 @@ pipeline {
                 stage('Kotti') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.20.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz"
                         sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
                         sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"
@@ -41,8 +41,8 @@ pipeline {
                 stage('Mordor') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.20.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz"
                         sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
                         sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"
@@ -61,8 +61,8 @@ pipeline {
                 stage('Goerli') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -L -O https://go.dev/dl/go1.18.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.20.3.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz"
                         sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
                         sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"


### PR DESCRIPTION
The CI on Jenkins failed to build geth
because minimum supported version is now
1.19. So bump to latest available Go version.

Date: 2023-04-25 08:41:50-07:00