### PR TITLE
Release/v1.12.11

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 12         // Minor version component of the current release
-	VersionPatch = 11         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 12       // Minor version component of the current release
+	VersionPatch = 11       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 11       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 12         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
This release merges upstream up to [ethereum/go-ethereum@v1.11.5](https://github.com/ethereum/go-ethereum/tree/v1.11.5).

# What's Changed

- Merge ethereum/go-ethereum release [v1.11.5](https://github.com/ethereum/go-ethereum/releases/tag/v1.11.5) https://github.com/etclabscore/core-geth/pull/531
- Remove additional core-geth configuration data types https://github.com/etclabscore/core-geth/pull/535

# Highlights

- eth/68 is the new best-default protocol 
- 2 `debug_` API methods gone, 4 new ones introduced.
- Added support for **Pebble DB**
- `personal` API is hashly deprecated, requiring opt-back-in with `--rpc.enabledeprecatedpersonal`.
- Removed iOS and Android builds.

---

Comparison with last release: [v1.12.10..v1.12.11](https://github.com/etclabscore/core-geth/compare/v1.12.10..v1.12.11)
Docker images published under [etclabscore/core-geth](https://hub.docker.com/r/etclabscore/core-geth/builds).