### PR TITLE
[zurich] Ghost-128 patch: downloader sync periodic TD check

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -158,9 +158,15 @@ type downloadTesterPeer struct {
 
 // Head constructs a function to retrieve a peer's current head hash
 // and total difficulty.
-func (dlp *downloadTesterPeer) Head() (common.Hash, *big.Int) {
+func (dlp *downloadTesterPeer) Head() (common.Hash, *big.Int, *big.Int) {
 	head := dlp.chain.CurrentBlock()
-	return head.Hash(), dlp.chain.GetTd(head.Hash(), head.Number.Uint64())
+	return head.Hash(), dlp.chain.GetTd(head.Hash(), head.Number.Uint64()), new(big.Int).Set(dlp.chain.CurrentBlock().Difficulty)
+}
+
+// SetHead constructs a function to retrieve a peer's current head hash
+// and total difficulty.
+func (dlp *downloadTesterPeer) SetHead(common.Hash, *big.Int, *big.Int) {
+	// noop
 }
 
 func unmarshalRlpHeaders(rlpdata []rlp.RawValue) []*types.Header {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -154,13 +154,18 @@ type downloadTesterPeer struct {
 	chain *core.BlockChain
 
 	withholdHeaders map[common.Hash]struct{}
+	fakeTD          *big.Int
 }
 
 // Head constructs a function to retrieve a peer's current head hash
 // and total difficulty.
 func (dlp *downloadTesterPeer) Head() (common.Hash, *big.Int, *big.Int) {
 	head := dlp.chain.CurrentBlock()
-	return head.Hash(), dlp.chain.GetTd(head.Hash(), head.Number.Uint64()), new(big.Int).Set(dlp.chain.CurrentBlock().Difficulty)
+	td := dlp.chain.GetTd(head.Hash(), head.Number.Uint64())
+	if dlp.fakeTD != nil {
+		td.Set(dlp.fakeTD)
+	}
+	return head.Hash(), td, new(big.Int).Set(dlp.chain.CurrentBlock().Difficulty)
 }
 
 // SetHead constructs a function to retrieve a peer's current head hash
@@ -992,8 +997,10 @@ func testHighTDStarvationAttack(t *testing.T, protocol uint, mode SyncMode) {
 	defer tester.terminate()
 
 	chain := testChainBase.shorten(1)
-	tester.newPeer("attack", protocol, chain.blocks[1:])
-	if err := tester.sync("attack", big.NewInt(1000000), mode); err != errStallingPeer {
+	dlp := tester.newPeer("attack", protocol, chain.blocks[1:])
+	fakeTD := big.NewInt(1000000)
+	dlp.fakeTD = fakeTD
+	if err := tester.sync("attack", fakeTD, mode); err != errStallingPeer {
 		t.Fatalf("synchronisation error mismatch: have %v, want %v", err, errStallingPeer)
 	}
 }

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -57,7 +57,8 @@ type peerConnection struct {
 
 // LightPeer encapsulates the methods required to synchronise with a remote light peer.
 type LightPeer interface {
-	Head() (common.Hash, *big.Int)
+	Head() (common.Hash, *big.Int, *big.Int)
+	SetHead(common.Hash, *big.Int, *big.Int)
 	RequestHeadersByHash(common.Hash, int, int, bool, chan *eth.Response) (*eth.Request, error)
 	RequestHeadersByNumber(uint64, int, int, bool, chan *eth.Response) (*eth.Request, error)
 }
@@ -74,7 +75,10 @@ type lightPeerWrapper struct {
 	peer LightPeer
 }
 
-func (w *lightPeerWrapper) Head() (common.Hash, *big.Int) { return w.peer.Head() }
+func (w *lightPeerWrapper) Head() (common.Hash, *big.Int, *big.Int) { return w.peer.Head() }
+func (w *lightPeerWrapper) SetHead(head common.Hash, td *big.Int, blockDifficulty *big.Int) {
+	w.peer.SetHead(head, td, blockDifficulty)
+}
 func (w *lightPeerWrapper) RequestHeadersByHash(h common.Hash, amount int, skip int, reverse bool, sink chan *eth.Response) (*eth.Request, error) {
 	return w.peer.RequestHeadersByHash(h, amount, skip, reverse, sink)
 }

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -188,7 +188,11 @@ func (p *skeletonTestPeer) RequestHeadersByNumber(origin uint64, amount int, ski
 	return req, nil
 }
 
-func (p *skeletonTestPeer) Head() (common.Hash, *big.Int) {
+func (p *skeletonTestPeer) Head() (common.Hash, *big.Int, *big.Int) {
+	panic("skeleton sync must not request the remote head")
+}
+
+func (p *skeletonTestPeer) SetHead(common.Hash, *big.Int, *big.Int) {
 	panic("skeleton sync must not request the remote head")
 }
 
@@ -514,7 +518,7 @@ func TestSkeletonSyncExtend(t *testing.T) {
 // Tests that the skeleton sync correctly retrieves headers from one or more
 // peers without duplicates or other strange side effects.
 func TestSkeletonSyncRetrievals(t *testing.T) {
-	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 
 	// Since skeleton headers don't need to be meaningful, beyond a parent hash
 	// progression, create a long fake chain to test with.

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -133,8 +133,8 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td
 		trueTD   = new(big.Int).Sub(td, block.Difficulty())
 	)
 	// Update the peer's total difficulty if better than the previous
-	if _, td := peer.Head(); trueTD.Cmp(td) > 0 {
-		peer.SetHead(trueHead, trueTD)
+	if _, td, _ := peer.Head(); trueTD.Cmp(td) > 0 {
+		peer.SetHead(trueHead, trueTD, block.Difficulty())
 		h.chainSync.handlePeerEvent(peer)
 	}
 	return nil

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -57,7 +57,7 @@ type ethPeer struct {
 
 // info gathers and returns some `eth` protocol metadata known about a peer.
 func (p *ethPeer) info() *ethPeerInfo {
-	hash, td := p.Head()
+	hash, td, _ := p.Head()
 
 	info := &ethPeerInfo{
 		Version:    p.Version(),

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -240,7 +240,7 @@ func (ps *peerSet) peerWithHighestTD() *eth.Peer {
 		bestTd   *big.Int
 	)
 	for _, p := range ps.peers {
-		if _, td := p.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
+		if _, td, _ := p.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
 			bestPeer, bestTd = p.Peer, td
 		}
 	}
@@ -268,7 +268,7 @@ func (ps *peerSet) WorstPeer() *ethPeer {
 		worstTD   *big.Int
 	)
 	for _, p := range ps.peers {
-		if _, td := p.Head(); worstPeer == nil || td.Cmp(worstTD) < 0 {
+		if _, td, _ := p.Head(); worstPeer == nil || td.Cmp(worstTD) < 0 {
 			worstPeer, worstTD = p, td
 		}
 	}

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -159,8 +159,6 @@ func (p *Peer) SetHead(hash common.Hash, td, blockDifficulty *big.Int) {
 	copy(p.head[:], hash[:])
 	p.td.Set(td)
 	p.blockDifficulty.Set(blockDifficulty)
-	//TODO: Remove following line
-	p.Peer.Log().Info("Updating head", "peer", p.ID(), "td", td)
 }
 
 // ForkID retrieves the reported forkid at the time of handshake.

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -258,7 +258,7 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 }
 
 func peerToSyncOp(mode downloader.SyncMode, p *eth.Peer) *chainSyncOp {
-	peerHead, peerTD := p.Head()
+	peerHead, peerTD, _ := p.Head()
 	return &chainSyncOp{mode: mode, peer: p, td: peerTD, head: peerHead}
 }
 


### PR DESCRIPTION
This patch applies the countermeasure
to security vulnerability Ghost-128 described
by Taverna and Paterson of ETH Zurich in their
2023 paper Snapping Snap Sync: Practical Attacks
on Synchronising Go-Ethereum Nodes.

This patch, in both its design and implementation,
was originally authored and provided by the authors
of that paper, and details around both can be
found in the paper's Section 7.

The patch has been edited only in adaptation
to minor application conflicts.