### PR TITLE
Fix "TestEth2PrepareAndGetPayload" random failures on GH Actions

### DIFF
--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -197,7 +197,7 @@ func TestEth2PrepareAndGetPayload(t *testing.T) {
 		t.Fatalf("error preparing payload, err=%v", err)
 	}
 	// give the payload some time to be built
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 	payloadID := (&miner.BuildPayloadArgs{
 		Parent:       fcState.HeadBlockHash,
 		Timestamp:    blockParams.Timestamp,


### PR DESCRIPTION
It resolves cases like it happened [here](https://github.com/etclabscore/core-geth/actions/runs/5014731854/jobs/8990764173#step:4:976)