### PR TITLE
Release/v1.12.12

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 12         // Minor version component of the current release
-	VersionPatch = 12         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 12       // Minor version component of the current release
+	VersionPatch = 12       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 12       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 13         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
This release merges upstream up to [ethereum/go-ethereum@1.11.6](https://github.com/ethereum/go-ethereum/tree/v1.11.6)

# What's Changed

- Merge ethereum/go-ethereum release [v1.11.6](https://github.com/ethereum/go-ethereum/releases/tag/v1.11.6) https://github.com/etclabscore/core-geth/pull/538
- Ghost-128 security patch https://github.com/etclabscore/core-geth/pull/544
