### PR TITLE
Rename RANDOM to PREVRANDAO in instruction set activation

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -194,7 +194,7 @@ func instructionSetForConfig(config ctypes.ChainConfigurator, isPostMerge bool, 
 		enable3198(instructionSet) // BASEFEE opcode https://eips.ethereum.org/EIPS/eip-3198
 	}
 	if isPostMerge {
-		instructionSet[RANDOM] = &operation{
+		instructionSet[PREVRANDAO] = &operation{
 			execute:     opRandom,
 			constantGas: GasQuickStep,
 			minStack:    minStack(0, 1),


### PR DESCRIPTION
During the merge from go-ethereum we wrongly handled the instruction to be activated for **RANDOM** which has been renamed to **PREVRANDAO**.

This can be found at https://github.com/ethereum/go-ethereum/commit/d30e39b2f833fb75f1e529cd405061fb6b548b8d#diff-3722385a96482d2250e1b71e50749b4a104968ca098dbb91331db536a37b3867L83