### PR TITLE
Release/v1.12.13

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 13       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 14         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 12         // Minor version component of the current release
-	VersionPatch = 13         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 12       // Minor version component of the current release
+	VersionPatch = 13       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
This release merges upstream up to [ethereum/go-ethereum@v1.12.0](https://github.com/ethereum/go-ethereum/tree/v1.12.0).

# What's Changed

- Merge ethereum/go-ethereum release [v1.12.0](https://github.com/ethereum/go-ethereum/releases/tag/v1.12.0). https://github.com/etclabscore/core-geth/pull/551
- Drops Kotti chain support. https://github.com/etclabscore/core-geth/pull/552

  > for syncing with Kotti, [v1.12.12](https://github.com/etclabscore/core-geth/releases/tag/v1.12.12) can be used. In advance, this [v1.12.13](https://github.com/etclabscore/core-geth/releases/tag/v1.12.13) can also be used by importing Kotti genesis in advance of syncing.

# Highlights

- In this merge we had to revert the changes made upstream with regards proof-of-work removal.
- core-geth defaults to use **Pebble** as a backend if no existing database is found (https://github.com/ethereum/go-ethereum/pull/27136). If a previous LevelDB database exists core-geth will keep using that, and if you must have LevelDB for some compatibility reasons, you can force it in Geth with the `--db.engine=leveldb` flag.



---

Comparison with last release: [v1.12.12..v1.12.13](https://github.com/etclabscore/core-geth/compare/v1.12.12..v1.12.13)
Docker images published under [etclabscore/core-geth](https://hub.docker.com/r/etclabscore/core-geth/builds).