### PR TITLE
Fix panic in lyra2 when mining

### DIFF
--- a/consensus/lyra2/consensus.go
+++ b/consensus/lyra2/consensus.go
@@ -394,7 +394,7 @@ func (lyra2 *Lyra2) FinalizeAndAssemble(chain consensus.ChainHeaderReader, heade
 	header.Root = state.IntermediateRoot(chain.Config().IsEnabled(chain.Config().GetEIP161dTransition, header.Number))
 
 	// Header seems complete, assemble into a block and return
-	return types.NewBlock(header, txs, uncles, receipts, new(trie.Trie)), nil
+	return types.NewBlock(header, txs, uncles, receipts, trie.NewStackTrie(nil)), nil
 }
 
 // SealHash returns the hash of a block prior to it being sealed.


### PR DESCRIPTION
This PR fixes panic when core-geth is running with `--mintme` flag and miner tries to create a new block.