### PR TITLE
consensus/ethash: remove spurious conditions preventing EIP3860, EIP4844 w/ Ethash

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -278,12 +278,7 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	if diff := new(big.Int).Sub(header.Number, parent.Number); diff.Cmp(big.NewInt(1)) != 0 {
 		return consensus.ErrInvalidNumber
 	}
-	if chain.Config().IsEnabledByTime(chain.Config().GetEIP3860TransitionTime, &header.Time) || chain.Config().IsEnabled(chain.Config().GetEIP3860Transition, header.Number) {
-		return fmt.Errorf("ethash does not support shanghai fork")
-	}
-	if chain.Config().IsEnabledByTime(chain.Config().GetEIP4844TransitionTime, &header.Time) {
-		return fmt.Errorf("ethash does not support cancun fork")
-	}
+
 	// Verify the engine specific seal securing the block
 	if seal {
 		if err := ethash.verifySeal(chain, header, false); err != nil {


### PR DESCRIPTION
These conditions prevented the enabling
of these EIPs with the Ethash consensus
engine by throwing an error if they were
enabled during header verification.
This behavior is incompatible with ETC's
planned use of these features, so we should
remove these conditions from header verification
and allow these EIPs to be enabled with
Ethash configuration.
I see no conceptual reason why 3860=
limit and meter init code and 4844=
blob tx types can not be used with Ethash
pow block sealing.

Date: 2023-10-10 11:25:31-06:00