### PR TITLE
Forkid tests

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -483,29 +483,34 @@ func TestEncoding(t *testing.T) {
 
 func TestGatherForks(t *testing.T) {
 	cases := []struct {
-		name   string
-		config ctypes.ChainConfigurator
-		wantNs []uint64
+		name       string
+		config     ctypes.ChainConfigurator
+		blockForks []uint64
+		timeForks  []uint64
 	}{
 		{
 			"classic",
 			params.ClassicChainConfig,
 			[]uint64{1150000, 2500000, 3000000, 5000000, 5900000, 8772000, 9573000, 10500839, 11_700_000, 13_189_133, 14_525_000},
+			[]uint64{},
 		},
 		{
 			"mainnet",
 			params.MainnetChainConfig,
 			[]uint64{1150000, 1920000, 2463000, 2675000, 4370000, 7280000, 9069000, 9200000, 12_244_000, 12_965_000, 13_773_000, 15050000},
+			[]uint64{1681338455 /* ShanghaiTime */},
 		},
 		{
 			"mordor",
 			params.MordorChainConfig,
 			[]uint64{301_243, 999_983, 2_520_000, 3_985_893, 5_520_000, 9_957_000},
+			[]uint64{},
 		},
 		{
 			"mintme",
 			params.MintMeChainConfig,
 			[]uint64{252_500},
+			[]uint64{},
 		},
 	}
 	sliceContains := func(sl []uint64, u uint64) bool {
@@ -516,19 +521,24 @@ func TestGatherForks(t *testing.T) {
 		}
 		return false
 	}
+	slicesEquivalent := func(sl1, sl2 []uint64) bool {
+		if len(sl1) != len(sl2) {
+			return false
+		}
+		for _, s := range sl1 {
+			if !sliceContains(sl2, s) {
+				return false
+			}
+		}
+		return true
+	}
 	for _, c := range cases {
-		blockForks, _ := gatherForks(c.config)
-		if len(blockForks) != len(c.wantNs) {
-			for _, n := range c.wantNs {
-				if !sliceContains(blockForks, n) {
-					t.Errorf("config=%s missing wanted fork at block number: %d", c.name, n)
-				}
-			}
-			for _, n := range blockForks {
-				if !sliceContains(c.wantNs, n) {
-					t.Errorf("config=%s gathered unwanted fork at block number: %d", c.name, n)
-				}
-			}
+		blockForks, timeForks := gatherForks(c.config)
+		if !slicesEquivalent(blockForks, c.blockForks) {
+			t.Errorf("config=%s block forks mismatch: have %v, want %v", c.name, blockForks, c.blockForks)
+		}
+		if !slicesEquivalent(timeForks, c.timeForks) {
+			t.Errorf("config=%s time forks mismatch: have %v, want %v", c.name, timeForks, c.timeForks)
 		}
 	}
 }

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -501,6 +501,18 @@ func TestGatherForks(t *testing.T) {
 			[]uint64{1681338455 /* ShanghaiTime */},
 		},
 		{
+			"goerli",
+			params.GoerliChainConfig,
+			[]uint64{1_561_651, 4_460_644, 5_062_605},
+			[]uint64{1678832736 /* ShanghaiTime */},
+		},
+		{
+			"sepolia",
+			params.SepoliaChainConfig,
+			[]uint64{1735371 /* Merge NetSplit */},
+			[]uint64{1677557088 /* ShanghaiTime */},
+		},
+		{
 			"mordor",
 			params.MordorChainConfig,
 			[]uint64{301_243, 999_983, 2_520_000, 3_985_893, 5_520_000, 9_957_000},


### PR DESCRIPTION
A small addition/fix to the `GatherForks` tests. Before, only block-based forks were checked. Now, also check time-based forks. Also add test cases for default networks Goerli and Sepolia.