### PR TITLE
Disable MESS

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -174,14 +174,14 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
 		}
 	}
-	if ctx.IsSet(utils.ECBP1100DeactivateFlag.Name) {
-		if n := ctx.Uint64(utils.ECBP1100DeactivateFlag.Name); n != math.MaxUint64 {
-			cfg.Eth.ECBP1100Deactivate = new(big.Int).SetUint64(n)
-		}
-	}
 	if ctx.IsSet(utils.ECBP1100NoDisableFlag.Name) {
 		if enable := ctx.Bool(utils.ECBP1100NoDisableFlag.Name); enable {
 			cfg.Eth.ECBP1100NoDisable = &enable
+		}
+	}
+	if ctx.IsSet(utils.OverrideECBP1100DeactivateFlag.Name) {
+		if n := ctx.Uint64(utils.OverrideECBP1100DeactivateFlag.Name); n != math.MaxUint64 {
+			cfg.Eth.OverrideECBP1100Deactivate = new(big.Int).SetUint64(n)
 		}
 	}
 	if ctx.IsSet(utils.OverrideShanghai.Name) {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -174,6 +174,11 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
 		}
 	}
+	if ctx.IsSet(utils.ECBP1100DisableFlag.Name) {
+		if n := ctx.Uint64(utils.ECBP1100DisableFlag.Name); n != math.MaxUint64 {
+			cfg.Eth.ECBP1100Disable = new(big.Int).SetUint64(n)
+		}
+	}
 	if ctx.IsSet(utils.ECBP1100NoDisableFlag.Name) {
 		if enable := ctx.Bool(utils.ECBP1100NoDisableFlag.Name); enable {
 			cfg.Eth.ECBP1100NoDisable = &enable

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -174,9 +174,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
 		}
 	}
-	if ctx.IsSet(utils.ECBP1100DisableFlag.Name) {
-		if n := ctx.Uint64(utils.ECBP1100DisableFlag.Name); n != math.MaxUint64 {
-			cfg.Eth.ECBP1100Disable = new(big.Int).SetUint64(n)
+	if ctx.IsSet(utils.ECBP1100DeactivateFlag.Name) {
+		if n := ctx.Uint64(utils.ECBP1100DeactivateFlag.Name); n != math.MaxUint64 {
+			cfg.Eth.ECBP1100Deactivate = new(big.Int).SetUint64(n)
 		}
 	}
 	if ctx.IsSet(utils.ECBP1100NoDisableFlag.Name) {

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -167,7 +167,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		utils.ECBP1100Flag,
 		utils.ECBP1100NoDisableFlag,
-		utils.ECBP1100DisableFlag,
+		utils.ECBP1100DeactivateFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -167,7 +167,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		utils.ECBP1100Flag,
 		utils.ECBP1100NoDisableFlag,
-		utils.ECBP1100DeactivateFlag,
+		utils.OverrideECBP1100DeactivateFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -167,6 +167,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		utils.ECBP1100Flag,
 		utils.ECBP1100NoDisableFlag,
+		utils.ECBP1100DisableFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1068,7 +1068,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,
 	}
-	ECBP1100DisableFlag = &cli.Uint64Flag{
+	ECBP1100DeactivateFlag = &cli.Uint64Flag{
 		Name:  "ecbp1100.disable",
 		Usage: "Disable ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1068,6 +1068,11 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Usage: "Configure ECBP-1100 (MESS) block activation number",
 		Value: math.MaxUint64,
 	}
+	ECBP1100DisableFlag = &cli.Uint64Flag{
+		Name:  "ecbp1100.disable",
+		Usage: "Disable ECBP-1100 (MESS) block activation number",
+		Value: math.MaxUint64,
+	}
 	ECBP1100NoDisableFlag = &cli.BoolFlag{
 		Name:  "ecbp1100.nodisable",
 		Usage: "Short-circuit ECBP-1100 (MESS) disable mechanisms; (yields a permanent-once-activated state, deactivating auto-shutoff mechanisms)",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2086,6 +2086,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
 	}
+	CheckExclusive(ctx, ECBP1100DisableFlag, ECBP1100NoDisableFlag)
+
 	// Override any default configs for hard coded networks.
 
 	// Override genesis configuration if a --<chain> flag.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1064,18 +1064,19 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Value: "",
 	}
 	ECBP1100Flag = &cli.Uint64Flag{
-		Name:  "ecbp1100",
-		Usage: "Configure ECBP-1100 (MESS) block activation number",
-		Value: math.MaxUint64,
+		Name:     "ecbp1100", // should have been override.ecbp1100, but maintained now for backwards compatibility
+		Usage:    "Manually specify the ECBP-1100 (MESS) block activation number, overriding the bundled setting",
+		Category: flags.EthCategory,
 	}
-	ECBP1100DeactivateFlag = &cli.Uint64Flag{
-		Name:  "ecbp1100.disable",
-		Usage: "Disable ECBP-1100 (MESS) block activation number",
-		Value: math.MaxUint64,
+	OverrideECBP1100DeactivateFlag = &cli.Uint64Flag{
+		Name:     "override.ecbp1100.deactivate",
+		Usage:    "Manually specify the ECBP-1100 (MESS) deactivation block number, overriding the bundled setting",
+		Category: flags.EthCategory,
 	}
 	ECBP1100NoDisableFlag = &cli.BoolFlag{
-		Name:  "ecbp1100.nodisable",
-		Usage: "Short-circuit ECBP-1100 (MESS) disable mechanisms; (yields a permanent-once-activated state, deactivating auto-shutoff mechanisms)",
+		Name:     "ecbp1100.nodisable",
+		Usage:    "Short-circuit ECBP-1100 (MESS) disable mechanisms; (yields a permanent-once-activated state, deactivating auto-shutoff mechanisms)",
+		Category: flags.DeprecatedCategory,
 	}
 
 	MetricsEnableInfluxDBV2Flag = &cli.BoolFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2086,7 +2086,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
 	}
-	CheckExclusive(ctx, ECBP1100DisableFlag, ECBP1100NoDisableFlag)
 
 	// Override any default configs for hard coded networks.
 

--- a/core/blockchain_af.go
+++ b/core/blockchain_af.go
@@ -27,7 +27,7 @@ func (bc *BlockChain) ArtificialFinalityNoDisable(n int32) {
 	if n == 1 {
 		disabledTransition := bc.chainConfig.GetECBP1100DisableTransition()
 		if disabledTransition != nil && big.NewInt(int64(*disabledTransition)).Cmp(big.NewInt(0)) > 0 {
-			log.Warn("Disable ECBP1100 (MESS) block activation number is set together with '--ecbp1100.nodisable'. ECBP1100 will not be disabled.", "disable transition block", *disabledTransition)
+			log.Warn("Disable ECBP1100 (MESS) block activation number is set together with '--ecbp1100.nodisable'.", "disable transition block", *disabledTransition)
 		}
 	}
 }

--- a/core/blockchain_af.go
+++ b/core/blockchain_af.go
@@ -23,6 +23,13 @@ func (bc *BlockChain) ArtificialFinalityNoDisable(n int32) {
 	log.Warn("Deactivating ECBP1100 (MESS) disablers", "always on", true)
 	bc.artificialFinalityNoDisable = new(int32)
 	atomic.StoreInt32(bc.artificialFinalityNoDisable, n)
+
+	if n == 1 {
+		disabledTransition := bc.chainConfig.GetECBP1100DisableTransition()
+		if disabledTransition != nil && big.NewInt(int64(*disabledTransition)).Cmp(big.NewInt(0)) > 0 {
+			log.Warn("Disable ECBP1100 (MESS) block activation number is set together with '--ecbp1100.nodisable'. ECBP1100 will not be disabled.", "disable transition block", *disabledTransition)
+		}
+	}
 }
 
 // EnableArtificialFinality enables and disable artificial finality features for the blockchain.

--- a/core/blockchain_af.go
+++ b/core/blockchain_af.go
@@ -20,14 +20,29 @@ var errReorgFinality = errors.New("finality-enforced invalid new chain")
 // n  = 1 : ON
 // n != 1 : OFF
 func (bc *BlockChain) ArtificialFinalityNoDisable(n int32) {
-	log.Warn("Deactivating ECBP1100 (MESS) disablers", "always on", true)
+	log.Warn("Deactivating ECBP1100 (MESS) safety mechanisms", "always on", true)
 	bc.artificialFinalityNoDisable = new(int32)
 	atomic.StoreInt32(bc.artificialFinalityNoDisable, n)
 
 	if n == 1 {
-		disabledTransition := bc.chainConfig.GetECBP1100DisableTransition()
-		if disabledTransition != nil && big.NewInt(int64(*disabledTransition)).Cmp(big.NewInt(0)) > 0 {
-			log.Warn("Disable ECBP1100 (MESS) block activation number is set together with '--ecbp1100.nodisable'.", "disable transition block", *disabledTransition)
+		deactivateTransition := bc.chainConfig.GetECBP1100DeactivateTransition()
+		if deactivateTransition != nil && big.NewInt(int64(*deactivateTransition)).Cmp(big.NewInt(0)) > 0 {
+			// Log the activation block as well as the deactivation block.
+			// Context is nice to have for the user.
+			var logActivationBlock uint64
+			logActivationBlockRaw := bc.chainConfig.GetECBP1100Transition()
+			if logActivationBlockRaw == nil {
+				// panic("impossible")
+				logActivationBlock = *deactivateTransition
+			} else {
+				logActivationBlock = *logActivationBlockRaw
+			}
+
+			log.Warn(`Deactivate-ECBP1100 (MESS) block activation number is set together with '--ecbp1100.nodisable'.
+The --ecbp1100.nodisable feature prevents the toggling of ECBP1100 (MESS) artificial finality with its safety mechanisms of low peer count and stale head.
+ECBP1100 (MESS) is scheduled for network-wide deactivation, rendering the --ecbp1100.nodisable feature anachronistic.
+`, "ECBP1100 activation block", logActivationBlock,
+				"ECBP1100 deactivation block", *deactivateTransition)
 		}
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -20,7 +20,6 @@ package eth
 import (
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"runtime"
 	"sync"
@@ -231,18 +230,16 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	eth.bloomIndexer.Start(eth.blockchain)
 	// Handle artificial finality config override cases.
-	if config.ECBP1100 != nil {
-		if n := config.ECBP1100.Uint64(); n != math.MaxUint64 {
-			if err := eth.blockchain.Config().SetECBP1100Transition(&n); err != nil {
-				return nil, err
-			}
+	if n := config.ECBP1100; n != nil {
+		v := n.Uint64()
+		if err := eth.blockchain.Config().SetECBP1100Transition(&v); err != nil {
+			return nil, err
 		}
 	}
-	if config.ECBP1100Deactivate != nil {
-		if n := config.ECBP1100Deactivate.Uint64(); n != math.MaxUint64 {
-			if err := eth.blockchain.Config().SetECBP1100DeactivateTransition(&n); err != nil {
-				return nil, err
-			}
+	if n := config.OverrideECBP1100Deactivate; n != nil {
+		v := n.Uint64()
+		if err := eth.blockchain.Config().SetECBP1100DeactivateTransition(&v); err != nil {
+			return nil, err
 		}
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -238,6 +238,14 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			}
 		}
 	}
+	if config.ECBP1100Disable != nil {
+		if n := config.ECBP1100Disable.Uint64(); n != math.MaxUint64 {
+			if err := eth.blockchain.Config().SetECBP1100DisableTransition(&n); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	if config.ECBP1100NoDisable != nil {
 		if *config.ECBP1100NoDisable {
 			eth.blockchain.ArtificialFinalityNoDisable(1)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -238,9 +238,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			}
 		}
 	}
-	if config.ECBP1100Disable != nil {
-		if n := config.ECBP1100Disable.Uint64(); n != math.MaxUint64 {
-			if err := eth.blockchain.Config().SetECBP1100DisableTransition(&n); err != nil {
+	if config.ECBP1100Deactivate != nil {
+		if n := config.ECBP1100Deactivate.Uint64(); n != math.MaxUint64 {
+			if err := eth.blockchain.Config().SetECBP1100DeactivateTransition(&n); err != nil {
 				return nil, err
 			}
 		}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -218,6 +218,8 @@ type Config struct {
 
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
 	ECBP1100 *big.Int
+	// Manual configuration field for ECBP1100's disablement block number. Used for modifying genesis config via CLI flag.
+	ECBP1100Disable *big.Int
 
 	// ECBP1100NoDisable overrides
 	// When this value is *true, ECBP100 will not (ever) be disabled; when *false, it will never be enabled.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -219,7 +219,7 @@ type Config struct {
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
 	ECBP1100 *big.Int
 	// Manual configuration field for ECBP1100's disablement block number. Used for modifying genesis config via CLI flag.
-	ECBP1100Disable *big.Int
+	ECBP1100Deactivate *big.Int
 
 	// ECBP1100NoDisable overrides
 	// When this value is *true, ECBP100 will not (ever) be disabled; when *false, it will never be enabled.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -219,7 +219,7 @@ type Config struct {
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
 	ECBP1100 *big.Int
 	// Manual configuration field for ECBP1100's disablement block number. Used for modifying genesis config via CLI flag.
-	ECBP1100Deactivate *big.Int
+	OverrideECBP1100Deactivate *big.Int
 
 	// ECBP1100NoDisable overrides
 	// When this value is *true, ECBP100 will not (ever) be disabled; when *false, it will never be enabled.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -119,7 +119,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.ECBP1100 = c.ECBP1100
-	enc.ECBP1100Disable = c.ECBP1100Deactivate
+	enc.ECBP1100Disable = c.OverrideECBP1100Deactivate
 	enc.ECBP1100NoDisable = c.ECBP1100NoDisable
 
 	enc.OverrideShanghai = c.OverrideShanghai
@@ -326,7 +326,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		c.ECBP1100 = dec.ECBP1100
 	}
 	if dec.ECBP1100Disable != nil {
-		c.ECBP1100Deactivate = dec.ECBP1100Disable
+		c.OverrideECBP1100Deactivate = dec.ECBP1100Disable
 	}
 	if dec.ECBP1100NoDisable != nil {
 		c.ECBP1100NoDisable = dec.ECBP1100NoDisable

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -66,6 +66,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Checkpoint              *ctypes.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *ctypes.CheckpointOracleConfig `toml:",omitempty"`
 		ECBP1100                *big.Int
+		ECBP1100Disable         *big.Int
 		ECBP1100NoDisable       *bool   `toml:",omitempty"`
 		OverrideShanghai        *uint64 `toml:",omitempty"`
 		OverrideCancun          *uint64 `toml:",omitempty"`
@@ -118,7 +119,9 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.ECBP1100 = c.ECBP1100
+	enc.ECBP1100Disable = c.ECBP1100Disable
 	enc.ECBP1100NoDisable = c.ECBP1100NoDisable
+
 	enc.OverrideShanghai = c.OverrideShanghai
 	enc.OverrideCancun = c.OverrideCancun
 	enc.OverrideVerkle = c.OverrideVerkle
@@ -174,6 +177,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		Checkpoint              *ctypes.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *ctypes.CheckpointOracleConfig `toml:",omitempty"`
 		ECBP1100                *big.Int
+		ECBP1100Disable         *big.Int
 		ECBP1100NoDisable       *bool   `toml:",omitempty"`
 		OverrideShanghai        *uint64 `toml:",omitempty"`
 		OverrideCancun          *uint64 `toml:",omitempty"`
@@ -320,6 +324,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.ECBP1100 != nil {
 		c.ECBP1100 = dec.ECBP1100
+	}
+	if dec.ECBP1100Disable != nil {
+		c.ECBP1100Disable = dec.ECBP1100Disable
 	}
 	if dec.ECBP1100NoDisable != nil {
 		c.ECBP1100NoDisable = dec.ECBP1100NoDisable

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -119,7 +119,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.ECBP1100 = c.ECBP1100
-	enc.ECBP1100Disable = c.ECBP1100Disable
+	enc.ECBP1100Disable = c.ECBP1100Deactivate
 	enc.ECBP1100NoDisable = c.ECBP1100NoDisable
 
 	enc.OverrideShanghai = c.OverrideShanghai
@@ -326,7 +326,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		c.ECBP1100 = dec.ECBP1100
 	}
 	if dec.ECBP1100Disable != nil {
-		c.ECBP1100Disable = dec.ECBP1100Disable
+		c.ECBP1100Deactivate = dec.ECBP1100Disable
 	}
 	if dec.ECBP1100NoDisable != nil {
 		c.ECBP1100NoDisable = dec.ECBP1100NoDisable

--- a/params/config_classic.go
+++ b/params/config_classic.go
@@ -81,9 +81,9 @@ var (
 		EIP2028FBlock: big.NewInt(10_500_839),
 		EIP2200FBlock: big.NewInt(10_500_839), // RePetersburg (=~ re-1283)
 
-		ECBP1100FBlock:        big.NewInt(11_380_000), // ETA 09 Oct 2020
-		ECBP1100DisableFBlock: big.NewInt(69_420_123),
-		ECIP1099FBlock:        big.NewInt(11_700_000), // Etchash (DAG size limit)
+		ECBP1100FBlock:           big.NewInt(11_380_000), // ETA 09 Oct 2020
+		ECBP1100DeactivateFBlock: big.NewInt(69_420_123),
+		ECIP1099FBlock:           big.NewInt(11_700_000), // Etchash (DAG size limit)
 
 		// Berlin eq, aka Magneto
 		EIP2565FBlock: big.NewInt(13_189_133),

--- a/params/config_classic.go
+++ b/params/config_classic.go
@@ -81,8 +81,9 @@ var (
 		EIP2028FBlock: big.NewInt(10_500_839),
 		EIP2200FBlock: big.NewInt(10_500_839), // RePetersburg (=~ re-1283)
 
-		ECBP1100FBlock: big.NewInt(11_380_000), // ETA 09 Oct 2020
-		ECIP1099FBlock: big.NewInt(11_700_000), // Etchash (DAG size limit)
+		ECBP1100FBlock:        big.NewInt(11_380_000), // ETA 09 Oct 2020
+		ECBP1100DisableFBlock: big.NewInt(69_420_123),
+		ECIP1099FBlock:        big.NewInt(11_700_000), // Etchash (DAG size limit)
 
 		// Berlin eq, aka Magneto
 		EIP2565FBlock: big.NewInt(13_189_133),

--- a/params/config_classic.go
+++ b/params/config_classic.go
@@ -82,7 +82,7 @@ var (
 		EIP2200FBlock: big.NewInt(10_500_839), // RePetersburg (=~ re-1283)
 
 		ECBP1100FBlock:           big.NewInt(11_380_000), // ETA 09 Oct 2020
-		ECBP1100DeactivateFBlock: big.NewInt(69_420_123),
+		ECBP1100DeactivateFBlock: big.NewInt(19_250_000), // ETA 31 Jan 2023 (== Spiral hard fork)
 		ECIP1099FBlock:           big.NewInt(11_700_000), // Etchash (DAG size limit)
 
 		// Berlin eq, aka Magneto

--- a/params/types/coregeth/chain_config.go
+++ b/params/types/coregeth/chain_config.go
@@ -184,8 +184,9 @@ type CoreGethChainConfig struct {
 	ECIP1017EraRounds  *big.Int `json:"ecip1017EraRounds,omitempty"` // ECIP1017 era rounds
 	ECIP1080FBlock     *big.Int `json:"ecip1080FBlock,omitempty"`
 
-	ECIP1099FBlock *big.Int `json:"ecip1099FBlock,omitempty"` // ECIP1099 etchash HF block
-	ECBP1100FBlock *big.Int `json:"ecbp1100FBlock,omitempty"` // ECBP1100:MESS artificial finality
+	ECIP1099FBlock        *big.Int `json:"ecip1099FBlock,omitempty"`        // ECIP1099 etchash HF block
+	ECBP1100FBlock        *big.Int `json:"ecbp1100FBlock,omitempty"`        // ECBP1100:MESS artificial finality
+	ECBP1100DisableFBlock *big.Int `json:"ecbp1100DisableFBlock,omitempty"` // Disable ECBP1100:MESS artificial finality
 
 	// EIP-2315: Simple Subroutines
 	// https://eips.ethereum.org/EIPS/eip-2315

--- a/params/types/coregeth/chain_config.go
+++ b/params/types/coregeth/chain_config.go
@@ -184,9 +184,9 @@ type CoreGethChainConfig struct {
 	ECIP1017EraRounds  *big.Int `json:"ecip1017EraRounds,omitempty"` // ECIP1017 era rounds
 	ECIP1080FBlock     *big.Int `json:"ecip1080FBlock,omitempty"`
 
-	ECIP1099FBlock        *big.Int `json:"ecip1099FBlock,omitempty"`        // ECIP1099 etchash HF block
-	ECBP1100FBlock        *big.Int `json:"ecbp1100FBlock,omitempty"`        // ECBP1100:MESS artificial finality
-	ECBP1100DisableFBlock *big.Int `json:"ecbp1100DisableFBlock,omitempty"` // Disable ECBP1100:MESS artificial finality
+	ECIP1099FBlock           *big.Int `json:"ecip1099FBlock,omitempty"`                 // ECIP1099 etchash HF block
+	ECBP1100FBlock           *big.Int `json:"ecbp1100FBlock,omitempty"`                 // ECBP1100:MESS artificial finality
+	ECBP1100DeactivateFBlock *big.Int `json:"ecbp1100DeactivateFBlockFBlock,omitempty"` // Deactivate ECBP1100:MESS artificial finality
 
 	// EIP-2315: Simple Subroutines
 	// https://eips.ethereum.org/EIPS/eip-2315

--- a/params/types/coregeth/chain_config_configurator.go
+++ b/params/types/coregeth/chain_config_configurator.go
@@ -28,6 +28,9 @@ package coregeth
 
 import (
 	"math/big"
+	"reflect"
+	"runtime"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -677,6 +680,13 @@ func (c *CoreGethChainConfig) IsEnabled(fn func() *uint64, n *big.Int) bool {
 	f := fn()
 	if f == nil || n == nil {
 		return false
+	}
+	fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	if strings.Contains(fnName, "ECBP1100Transition") {
+		disabledTransition := c.GetECBP1100DisableTransition()
+		if disabledTransition != nil {
+			return big.NewInt(int64(*disabledTransition)).Cmp(n) > 0 && big.NewInt(int64(*f)).Cmp(n) <= 0
+		}
 	}
 	return big.NewInt(int64(*f)).Cmp(n) <= 0
 }

--- a/params/types/coregeth/chain_config_configurator.go
+++ b/params/types/coregeth/chain_config_configurator.go
@@ -427,12 +427,12 @@ func (c *CoreGethChainConfig) SetECBP1100Transition(n *uint64) error {
 	return nil
 }
 
-func (c *CoreGethChainConfig) GetECBP1100DisableTransition() *uint64 {
-	return bigNewU64(c.ECBP1100DisableFBlock)
+func (c *CoreGethChainConfig) GetECBP1100DeactivateTransition() *uint64 {
+	return bigNewU64(c.ECBP1100DeactivateFBlock)
 }
 
-func (c *CoreGethChainConfig) SetECBP1100DisableTransition(n *uint64) error {
-	c.ECBP1100DisableFBlock = setBig(c.ECBP1100DisableFBlock, n)
+func (c *CoreGethChainConfig) SetECBP1100DeactivateTransition(n *uint64) error {
+	c.ECBP1100DeactivateFBlock = setBig(c.ECBP1100DeactivateFBlock, n)
 	return nil
 }
 
@@ -683,9 +683,9 @@ func (c *CoreGethChainConfig) IsEnabled(fn func() *uint64, n *big.Int) bool {
 	}
 	fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 	if strings.Contains(fnName, "ECBP1100Transition") {
-		disabledTransition := c.GetECBP1100DisableTransition()
-		if disabledTransition != nil {
-			return big.NewInt(int64(*disabledTransition)).Cmp(n) > 0 && big.NewInt(int64(*f)).Cmp(n) <= 0
+		deactivateTransition := c.GetECBP1100DeactivateTransition()
+		if deactivateTransition != nil {
+			return big.NewInt(int64(*deactivateTransition)).Cmp(n) > 0 && big.NewInt(int64(*f)).Cmp(n) <= 0
 		}
 	}
 	return big.NewInt(int64(*f)).Cmp(n) <= 0

--- a/params/types/coregeth/chain_config_configurator.go
+++ b/params/types/coregeth/chain_config_configurator.go
@@ -424,6 +424,15 @@ func (c *CoreGethChainConfig) SetECBP1100Transition(n *uint64) error {
 	return nil
 }
 
+func (c *CoreGethChainConfig) GetECBP1100DisableTransition() *uint64 {
+	return bigNewU64(c.ECBP1100DisableFBlock)
+}
+
+func (c *CoreGethChainConfig) SetECBP1100DisableTransition(n *uint64) error {
+	c.ECBP1100DisableFBlock = setBig(c.ECBP1100DisableFBlock, n)
+	return nil
+}
+
 func (c *CoreGethChainConfig) GetEIP2315Transition() *uint64 {
 	return bigNewU64(c.EIP2315FBlock)
 }

--- a/params/types/coregeth/chain_config_test.go
+++ b/params/types/coregeth/chain_config_test.go
@@ -49,3 +49,43 @@ func TestCoreGethChainConfig_String(t *testing.T) {
 	t.Skip("(noop) development use only")
 	t.Log(testConfig.String())
 }
+
+func TestCoreGethChainConfig_ECBP1100Disable(t *testing.T) {
+	var _testConfig = &CoreGethChainConfig{}
+	*_testConfig = *testConfig
+
+	enable := uint64(100)
+	disable := uint64(200)
+	_testConfig.SetECBP1100Transition(&enable)
+	_testConfig.SetECBP1100DisableTransition(&disable)
+
+	n := uint64(10)
+	bigN := new(big.Int).SetUint64(n)
+	if _testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
+		t.Errorf("ECBP1100 should be not yet be enabled at block %d", n)
+	}
+
+	n = uint64(100)
+	bigN = new(big.Int).SetUint64(n)
+	if !_testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
+		t.Errorf("ECBP1100 should be enabled at block %d", n)
+	}
+
+	n = uint64(110)
+	bigN = new(big.Int).SetUint64(n)
+	if !_testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
+		t.Errorf("ECBP1100 should be enabled at block %d", n)
+	}
+
+	n = uint64(200)
+	bigN = new(big.Int).SetUint64(n)
+	if _testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
+		t.Errorf("ECBP1100 should be disabled at block %d", n)
+	}
+
+	n = uint64(210)
+	bigN = new(big.Int).SetUint64(n)
+	if _testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
+		t.Errorf("ECBP1100 should be disabled at block %d", n)
+	}
+}

--- a/params/types/coregeth/chain_config_test.go
+++ b/params/types/coregeth/chain_config_test.go
@@ -50,42 +50,42 @@ func TestCoreGethChainConfig_String(t *testing.T) {
 	t.Log(testConfig.String())
 }
 
-func TestCoreGethChainConfig_ECBP1100Disable(t *testing.T) {
+func TestCoreGethChainConfig_ECBP1100Deactivate(t *testing.T) {
 	var _testConfig = &CoreGethChainConfig{}
 	*_testConfig = *testConfig
 
-	enable := uint64(100)
-	disable := uint64(200)
-	_testConfig.SetECBP1100Transition(&enable)
-	_testConfig.SetECBP1100DisableTransition(&disable)
+	activate := uint64(100)
+	deactivate := uint64(200)
+	_testConfig.SetECBP1100Transition(&activate)
+	_testConfig.SetECBP1100DeactivateTransition(&deactivate)
 
 	n := uint64(10)
 	bigN := new(big.Int).SetUint64(n)
 	if _testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
-		t.Errorf("ECBP1100 should be not yet be enabled at block %d", n)
+		t.Errorf("ECBP1100 should be not yet be activated at block %d", n)
 	}
 
 	n = uint64(100)
 	bigN = new(big.Int).SetUint64(n)
 	if !_testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
-		t.Errorf("ECBP1100 should be enabled at block %d", n)
+		t.Errorf("ECBP1100 should be activated at block %d", n)
 	}
 
 	n = uint64(110)
 	bigN = new(big.Int).SetUint64(n)
 	if !_testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
-		t.Errorf("ECBP1100 should be enabled at block %d", n)
+		t.Errorf("ECBP1100 should be activated at block %d", n)
 	}
 
 	n = uint64(200)
 	bigN = new(big.Int).SetUint64(n)
 	if _testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
-		t.Errorf("ECBP1100 should be disabled at block %d", n)
+		t.Errorf("ECBP1100 should be deactivated at block %d", n)
 	}
 
 	n = uint64(210)
 	bigN = new(big.Int).SetUint64(n)
 	if _testConfig.IsEnabled(_testConfig.GetECBP1100Transition, bigN) {
-		t.Errorf("ECBP1100 should be disabled at block %d", n)
+		t.Errorf("ECBP1100 should be deactivated at block %d", n)
 	}
 }

--- a/params/types/ctypes/configurator_iface.go
+++ b/params/types/ctypes/configurator_iface.go
@@ -142,6 +142,9 @@ type ProtocolSpecifier interface {
 
 	GetECBP1100Transition() *uint64
 	SetECBP1100Transition(n *uint64) error
+	GetECBP1100DisableTransition() *uint64
+	SetECBP1100DisableTransition(n *uint64) error
+
 	GetEIP2315Transition() *uint64
 	SetEIP2315Transition(n *uint64) error
 

--- a/params/types/ctypes/configurator_iface.go
+++ b/params/types/ctypes/configurator_iface.go
@@ -142,8 +142,8 @@ type ProtocolSpecifier interface {
 
 	GetECBP1100Transition() *uint64
 	SetECBP1100Transition(n *uint64) error
-	GetECBP1100DisableTransition() *uint64
-	SetECBP1100DisableTransition(n *uint64) error
+	GetECBP1100DeactivateTransition() *uint64
+	SetECBP1100DeactivateTransition(n *uint64) error
 
 	GetEIP2315Transition() *uint64
 	SetEIP2315Transition(n *uint64) error

--- a/params/types/genesisT/genesis.go
+++ b/params/types/genesisT/genesis.go
@@ -789,6 +789,14 @@ func (g *Genesis) SetECBP1100Transition(n *uint64) error {
 	return g.Config.SetECBP1100Transition(n)
 }
 
+func (g *Genesis) GetECBP1100DisableTransition() *uint64 {
+	return g.Config.GetECBP1100DisableTransition()
+}
+
+func (g *Genesis) SetECBP1100DisableTransition(n *uint64) error {
+	return g.Config.SetECBP1100DisableTransition(n)
+}
+
 func (g *Genesis) IsEnabled(fn func() *uint64, n *big.Int) bool {
 	return g.Config.IsEnabled(fn, n)
 }

--- a/params/types/genesisT/genesis.go
+++ b/params/types/genesisT/genesis.go
@@ -789,12 +789,12 @@ func (g *Genesis) SetECBP1100Transition(n *uint64) error {
 	return g.Config.SetECBP1100Transition(n)
 }
 
-func (g *Genesis) GetECBP1100DisableTransition() *uint64 {
-	return g.Config.GetECBP1100DisableTransition()
+func (g *Genesis) GetECBP1100DeactivateTransition() *uint64 {
+	return g.Config.GetECBP1100DeactivateTransition()
 }
 
-func (g *Genesis) SetECBP1100DisableTransition(n *uint64) error {
-	return g.Config.SetECBP1100DisableTransition(n)
+func (g *Genesis) SetECBP1100DeactivateTransition(n *uint64) error {
+	return g.Config.SetECBP1100DeactivateTransition(n)
 }
 
 func (g *Genesis) IsEnabled(fn func() *uint64, n *big.Int) bool {

--- a/params/types/goethereum/goethereum.go
+++ b/params/types/goethereum/goethereum.go
@@ -99,8 +99,8 @@ type ChainConfig struct {
 	ECIP1080Transition *big.Int `json:"-"`
 
 	// Cache types for use with testing, but will not show up in config API.
-	ecbp1100Transition        *big.Int
-	ecbp1100DisableTransition *big.Int
+	ecbp1100Transition           *big.Int
+	ecbp1100DeactivateTransition *big.Int
 
 	Lyra2NonceTransitionBlock *big.Int `json:"lyra2NonceTransitionBlock,omitempty"`
 }

--- a/params/types/goethereum/goethereum.go
+++ b/params/types/goethereum/goethereum.go
@@ -99,7 +99,8 @@ type ChainConfig struct {
 	ECIP1080Transition *big.Int `json:"-"`
 
 	// Cache types for use with testing, but will not show up in config API.
-	ecbp1100Transition *big.Int
+	ecbp1100Transition        *big.Int
+	ecbp1100DisableTransition *big.Int
 
 	Lyra2NonceTransitionBlock *big.Int `json:"lyra2NonceTransitionBlock,omitempty"`
 }

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -18,6 +18,9 @@ package goethereum
 
 import (
 	"math/big"
+	"reflect"
+	"runtime"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
@@ -699,6 +702,13 @@ func (c *ChainConfig) IsEnabled(fn func() *uint64, n *big.Int) bool {
 	f := fn()
 	if f == nil || n == nil {
 		return false
+	}
+	fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	if strings.Contains(fnName, "ECBP1100Transition") {
+		disabledTransition := c.GetECBP1100DisableTransition()
+		if disabledTransition != nil {
+			return big.NewInt(int64(*disabledTransition)).Cmp(n) > 0 && big.NewInt(int64(*f)).Cmp(n) <= 0
+		}
 	}
 	return big.NewInt(int64(*f)).Cmp(n) <= 0
 }

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -452,12 +452,12 @@ func (c *ChainConfig) SetECBP1100Transition(n *uint64) error {
 	return nil
 }
 
-func (c *ChainConfig) GetECBP1100DisableTransition() *uint64 {
-	return bigNewU64(c.ecbp1100DisableTransition)
+func (c *ChainConfig) GetECBP1100DeactivateTransition() *uint64 {
+	return bigNewU64(c.ecbp1100DeactivateTransition)
 }
 
-func (c *ChainConfig) SetECBP1100DisableTransition(n *uint64) error {
-	c.ecbp1100DisableTransition = setBig(c.ecbp1100DisableTransition, n)
+func (c *ChainConfig) SetECBP1100DeactivateTransition(n *uint64) error {
+	c.ecbp1100DeactivateTransition = setBig(c.ecbp1100DeactivateTransition, n)
 	return nil
 }
 
@@ -705,9 +705,9 @@ func (c *ChainConfig) IsEnabled(fn func() *uint64, n *big.Int) bool {
 	}
 	fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 	if strings.Contains(fnName, "ECBP1100Transition") {
-		disabledTransition := c.GetECBP1100DisableTransition()
-		if disabledTransition != nil {
-			return big.NewInt(int64(*disabledTransition)).Cmp(n) > 0 && big.NewInt(int64(*f)).Cmp(n) <= 0
+		deactivateTransition := c.GetECBP1100DeactivateTransition()
+		if deactivateTransition != nil {
+			return big.NewInt(int64(*deactivateTransition)).Cmp(n) > 0 && big.NewInt(int64(*f)).Cmp(n) <= 0
 		}
 	}
 	return big.NewInt(int64(*f)).Cmp(n) <= 0

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -449,6 +449,15 @@ func (c *ChainConfig) SetECBP1100Transition(n *uint64) error {
 	return nil
 }
 
+func (c *ChainConfig) GetECBP1100DisableTransition() *uint64 {
+	return bigNewU64(c.ecbp1100DisableTransition)
+}
+
+func (c *ChainConfig) SetECBP1100DisableTransition(n *uint64) error {
+	c.ecbp1100DisableTransition = setBig(c.ecbp1100DisableTransition, n)
+	return nil
+}
+
 // GetEIP2315Transition implements EIP2537.
 // This logic is written but not configured for any Ethereum-supported networks, yet.
 func (c *ChainConfig) GetEIP2315Transition() *uint64 {


### PR DESCRIPTION
This PR drafts the disablement of  [MESS/ECBP1100](https://ecips.ethereumclassic.org/ECIPs/ecip-1100), anticipated to occur on ETC concurrently with the [Spiral](https://ecips.ethereumclassic.org/ECIPs/ecip-1109) network upgrade. 

Following convention, a configuration override flag `--ecbp1100.disable=[number]` is provided.

As-is, this draft uses `runtime` and `reflect` at the `Configurator` implementation level to handle the actual enable/disable logic (https://github.com/etclabscore/core-geth/commit/9e274d02851888a9dab51d5ba197193f09aa2b24). Alternatively, we could consider instead adding conditions at the places where the configuration is referenced to handle it, like the example below.

```diff
diff --git a/core/forkchoice.go b/core/forkchoice.go
index d07cdf6aa4..55d898c3a0 100644
--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -162,7 +162,8 @@ func (f *ForkChoice) ReorgNeeded(current *types.Header, extern *types.Header) (b
                        return reorg, nil
                }
        }
-       if !f.chain.Config().IsEnabled(f.chain.Config().GetECBP1100Transition, current.Number) {
+       if !f.chain.Config().IsEnabled(f.chain.Config().GetECBP1100Transition, current.Number) ||
+               f.chain.Config().IsEnabled(f.chain.Config().GetECBP1100DisableTransition, current.Number) {
                return reorg, nil
        }

```