### PR TITLE
Fix/miner downloader autopause

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -32,6 +32,13 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
+// InsertBlockEvent is posted by the handler when a propagated block is successfully imported.
+// The block may have been propagated via announcement (hashes) or broadcast (full block, via its miner).
+// The event should not be posted if the insert function returns any error.
+type InsertBlockEvent struct {
+	Block *types.Block
+}
+
 const (
 	lightTimeout  = time.Millisecond       // Time allowance before an announced header is explicitly requested
 	arriveTimeout = 500 * time.Millisecond // Time allowance before an announced block/transaction is explicitly requested

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -32,11 +32,11 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-// InsertBlockEvent is posted by the handler when a propagated block is successfully imported.
+// InsertChainEvent is posted by the handler when a propagated block is successfully imported.
 // The block may have been propagated via announcement (hashes) or broadcast (full block, via its miner).
 // The event should not be posted if the insert function returns any error.
-type InsertBlockEvent struct {
-	Block *types.Block
+type InsertChainEvent struct {
+	Blocks types.Blocks
 }
 
 const (

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -294,6 +294,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		n, err := h.chain.InsertChain(blocks)
 		if err == nil {
 			h.acceptTxs.Store(true) // Mark initial sync done on any fetcher import
+			h.eventMux.Post(fetcher.InsertBlockEvent{Block: blocks[0]})
 		}
 		return n, err
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -295,7 +295,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		if err == nil {
 			// Mark initial sync done on any fetcher import
 			h.acceptTxs.Store(true)
-			h.eventMux.Post(fetcher.InsertBlockEvent{Block: blocks[0]})
+			h.eventMux.Post(fetcher.InsertChainEvent{Blocks: blocks})
 		}
 		return n, err
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -293,7 +293,8 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 		n, err := h.chain.InsertChain(blocks)
 		if err == nil {
-			h.acceptTxs.Store(true) // Mark initial sync done on any fetcher import
+			// Mark initial sync done on any fetcher import
+			h.acceptTxs.Store(true)
 			h.eventMux.Post(fetcher.InsertBlockEvent{Block: blocks[0]})
 		}
 		return n, err

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/fetcher"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
@@ -107,7 +108,7 @@ func New(eth Backend, config *Config, chainConfig ctypes.ChainConfigurator, mux 
 func (miner *Miner) update() {
 	defer miner.wg.Done()
 
-	events := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	events := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{}, fetcher.InsertBlockEvent{})
 	defer func() {
 		if !events.Closed() {
 			events.Unsubscribe()
@@ -116,13 +117,13 @@ func (miner *Miner) update() {
 
 	shouldStart := false
 	canStart := true
-	dlEventCh := events.Chan()
+	eventCh := events.Chan()
 	for {
 		select {
-		case ev := <-dlEventCh:
+		case ev := <-eventCh:
 			if ev == nil {
 				// Unsubscription done, stop listening
-				dlEventCh = nil
+				eventCh = nil
 				continue
 			}
 			switch ev.Data.(type) {
@@ -143,6 +144,19 @@ func (miner *Miner) update() {
 				}
 				miner.worker.syncing.Store(false)
 			case downloader.DoneEvent:
+				canStart = true
+				if shouldStart {
+					miner.worker.start()
+				}
+				miner.worker.syncing.Store(false)
+				// Stop reacting to downloader events
+				events.Unsubscribe()
+			case fetcher.InsertBlockEvent:
+				// InsertBlockEvents are posted by the block fetcher, which handles the fetching and importing
+				// of network head blocks.
+				// This event should be treated by the miner equivalently to the downloader.DoneEvent;
+				// both events indicate that the local node should be treated as fully synced
+				// and thus ready to mine.
 				canStart = true
 				if shouldStart {
 					miner.worker.start()

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -143,15 +143,7 @@ func (miner *Miner) update() {
 					miner.worker.start()
 				}
 				miner.worker.syncing.Store(false)
-			case downloader.DoneEvent:
-				canStart = true
-				if shouldStart {
-					miner.worker.start()
-				}
-				miner.worker.syncing.Store(false)
-				// Stop reacting to downloader events
-				events.Unsubscribe()
-			case fetcher.InsertBlockEvent:
+			case downloader.DoneEvent, fetcher.InsertBlockEvent:
 				// InsertBlockEvents are posted by the block fetcher, which handles the fetching and importing
 				// of network head blocks.
 				// This event should be treated by the miner equivalently to the downloader.DoneEvent;

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -108,7 +108,7 @@ func New(eth Backend, config *Config, chainConfig ctypes.ChainConfigurator, mux 
 func (miner *Miner) update() {
 	defer miner.wg.Done()
 
-	events := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{}, fetcher.InsertBlockEvent{})
+	events := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{}, fetcher.InsertChainEvent{})
 	defer func() {
 		if !events.Closed() {
 			events.Unsubscribe()
@@ -143,7 +143,7 @@ func (miner *Miner) update() {
 					miner.worker.start()
 				}
 				miner.worker.syncing.Store(false)
-			case downloader.DoneEvent, fetcher.InsertBlockEvent:
+			case downloader.DoneEvent, fetcher.InsertChainEvent:
 				// InsertBlockEvents are posted by the block fetcher, which handles the fetching and importing
 				// of network head blocks.
 				// This event should be treated by the miner equivalently to the downloader.DoneEvent;

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/fetcher"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
@@ -180,6 +181,60 @@ func TestMinerStartStopAfterDownloaderEvents(t *testing.T) {
 
 	miner.Stop()
 	waitForMiningState(t, miner, false)
+}
+
+// TestMinerStartAfterFetcherInsertEvent tests that the miner resumes mining during a downloader sync attempt
+// if a propagated block (announce, broadcast) is inserted successfully to the local chain.
+func TestMinerStartAfterFetcherInsertEvent(t *testing.T) {
+	miner, mux, cleanup := createMiner(t)
+	defer cleanup(false)
+
+	miner.Start()
+	waitForMiningState(t, miner, true)
+	// Start the downloader
+	mux.Post(downloader.StartEvent{})
+	waitForMiningState(t, miner, false)
+
+	// During the sync, import a block via the fetcher.
+	// Miner should resume mining, inferring that we're at or near-enough (<32 block) the head of the network canonical chain.
+	mux.Post(fetcher.InsertBlockEvent{})
+	waitForMiningState(t, miner, true)
+
+	mux.Post(downloader.FailedEvent{})
+	waitForMiningState(t, miner, true)
+
+	mux.Post(downloader.StartEvent{})
+	waitForMiningState(t, miner, true) // Has not autopaused mining.
+
+	// Downloader finally succeeds.
+	mux.Post(downloader.DoneEvent{})
+	waitForMiningState(t, miner, true) // Still mining.
+}
+
+// TestMinerStartAfterFetcherInsertEvent2 tests that the miner does not autopause if outside any downloader sync attempt
+// a propagated block (announce, broadcast) is inserted successfully to the local chain; that is,
+// a fetcher->import event disables the downloader event listener and autopause mechanism.
+func TestMinerStartAfterFetcherInsertEvent2(t *testing.T) {
+	miner, mux, cleanup := createMiner(t)
+	defer cleanup(false)
+
+	miner.Start()
+	waitForMiningState(t, miner, true)
+
+	// Before we've started the downloader, import a block via the fetcher.
+	// This should disable subsequent autopausing for downloader events thereafter, since
+	// we consider the local chain sufficiently synced.
+	mux.Post(fetcher.InsertBlockEvent{})
+	waitForMiningState(t, miner, true)
+
+	// Start the downloader
+	mux.Post(downloader.StartEvent{})
+	// Still mining; we've inferred by a successful import of a propagated block
+	// that we're already synced, and we're no longer treating downloader events as autopause-able.
+	waitForMiningState(t, miner, true)
+
+	mux.Post(downloader.FailedEvent{})
+	waitForMiningState(t, miner, true)
 }
 
 func TestStartWhileDownload(t *testing.T) {

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -197,7 +197,7 @@ func TestMinerStartAfterFetcherInsertEvent(t *testing.T) {
 
 	// During the sync, import a block via the fetcher.
 	// Miner should resume mining, inferring that we're at or near-enough (<32 block) the head of the network canonical chain.
-	mux.Post(fetcher.InsertBlockEvent{})
+	mux.Post(fetcher.InsertChainEvent{})
 	waitForMiningState(t, miner, true)
 
 	mux.Post(downloader.FailedEvent{})
@@ -224,7 +224,7 @@ func TestMinerStartAfterFetcherInsertEvent2(t *testing.T) {
 	// Before we've started the downloader, import a block via the fetcher.
 	// This should disable subsequent autopausing for downloader events thereafter, since
 	// we consider the local chain sufficiently synced.
-	mux.Post(fetcher.InsertBlockEvent{})
+	mux.Post(fetcher.InsertChainEvent{})
 	waitForMiningState(t, miner, true)
 
 	// Start the downloader


### PR DESCRIPTION
Read https://github.com/ethereum/devp2p/blob/master/caps/eth.md#block-propagation.

This patch infers "synced" status by the successful status of a `BlockFetcher`-directed chain insertion. 

The `BlockFetcher` type exclusively handles the (optional) fetching and (always) importing of block(s) received via the following wire protocol messages.
- https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07
- https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01

If a block is successfully inserted into our local chain by these means, the miner infers that we are synced, and disables the autopause-for-downloader-events mechanism.

Resolves #586 