### PR TITLE
Release/v1.12.17

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 12         // Minor version component of the current release
-	VersionPatch = 17         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 12       // Minor version component of the current release
+	VersionPatch = 17       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 17       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 18         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
This release includes an important fix for a miner DoS vulnerability, where an attacker could toggle mining intermittently by broadcasting statuses with fake total difficulties. All users are recommended to upgrade to this version or later.

## What's Changed

- [Spiral hardfork](https://ecips.ethereumclassic.org/ECIPs/ecip-1109) activation values for ETC mainnet are configured per spec. Block `19_250_000`, eta January 31, 2024. 
- [MESS (ECBP1100)](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1100.md) is scheduled to deactivate coincidentally with the Spiral hard fork.

## Fixes

-  Fix miner auto-pause vulnerability (#596)