### PR TITLE
Fix config toml, go generate

### DIFF
--- a/.github/workflows/go-generate-check.yml
+++ b/.github/workflows/go-generate-check.yml
@@ -1,5 +1,7 @@
 name: Developer helper
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 env:
   # GENERATE_EXCEPTIONS are exceptions made to the 'go generate' command.
   # These patterns are matched (negatively) against 'go list' output.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -170,7 +170,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	stack, cfg := makeConfigNode(ctx)
 	if ctx.IsSet(utils.ECBP1100Flag.Name) {
 		if n := ctx.Uint64(utils.ECBP1100Flag.Name); n != math.MaxUint64 {
-			cfg.Eth.ECBP1100 = &n
+			cfg.Eth.OverrideECBP1100 = &n
 		}
 	}
 	if ctx.IsSet(utils.ECBP1100NoDisableFlag.Name) {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 	"os"
 	"reflect"
 	"unicode"
@@ -171,7 +170,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	stack, cfg := makeConfigNode(ctx)
 	if ctx.IsSet(utils.ECBP1100Flag.Name) {
 		if n := ctx.Uint64(utils.ECBP1100Flag.Name); n != math.MaxUint64 {
-			cfg.Eth.ECBP1100 = new(big.Int).SetUint64(n)
+			cfg.Eth.ECBP1100 = &n
 		}
 	}
 	if ctx.IsSet(utils.ECBP1100NoDisableFlag.Name) {
@@ -181,7 +180,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	}
 	if ctx.IsSet(utils.OverrideECBP1100DeactivateFlag.Name) {
 		if n := ctx.Uint64(utils.OverrideECBP1100DeactivateFlag.Name); n != math.MaxUint64 {
-			cfg.Eth.OverrideECBP1100Deactivate = new(big.Int).SetUint64(n)
+			cfg.Eth.OverrideECBP1100Deactivate = &n
 		}
 	}
 	if ctx.IsSet(utils.OverrideShanghai.Name) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -231,14 +231,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.bloomIndexer.Start(eth.blockchain)
 	// Handle artificial finality config override cases.
 	if n := config.ECBP1100; n != nil {
-		v := n.Uint64()
-		if err := eth.blockchain.Config().SetECBP1100Transition(&v); err != nil {
+		if err := eth.blockchain.Config().SetECBP1100Transition(n); err != nil {
 			return nil, err
 		}
 	}
 	if n := config.OverrideECBP1100Deactivate; n != nil {
-		v := n.Uint64()
-		if err := eth.blockchain.Config().SetECBP1100DeactivateTransition(&v); err != nil {
+		if err := eth.blockchain.Config().SetECBP1100DeactivateTransition(n); err != nil {
 			return nil, err
 		}
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -230,7 +230,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	eth.bloomIndexer.Start(eth.blockchain)
 	// Handle artificial finality config override cases.
-	if n := config.ECBP1100; n != nil {
+	if n := config.OverrideECBP1100; n != nil {
 		if err := eth.blockchain.Config().SetECBP1100Transition(n); err != nil {
 			return nil, err
 		}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -216,9 +216,9 @@ type Config struct {
 	CheckpointOracle *ctypes.CheckpointOracleConfig `toml:",omitempty"`
 
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
-	ECBP1100 *uint64
+	ECBP1100 *uint64 `toml:",omitempty"`
 	// Manual configuration field for ECBP1100's disablement block number. Used for modifying genesis config via CLI flag.
-	OverrideECBP1100Deactivate *uint64
+	OverrideECBP1100Deactivate *uint64 `toml:",omitempty"`
 
 	// ECBP1100NoDisable overrides
 	// When this value is *true, ECBP100 will not (ever) be disabled; when *false, it will never be enabled.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -18,7 +18,6 @@
 package ethconfig
 
 import (
-	"math/big"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -217,9 +216,9 @@ type Config struct {
 	CheckpointOracle *ctypes.CheckpointOracleConfig `toml:",omitempty"`
 
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
-	ECBP1100 *big.Int
+	ECBP1100 *uint64
 	// Manual configuration field for ECBP1100's disablement block number. Used for modifying genesis config via CLI flag.
-	OverrideECBP1100Deactivate *big.Int
+	OverrideECBP1100Deactivate *uint64
 
 	// ECBP1100NoDisable overrides
 	// When this value is *true, ECBP100 will not (ever) be disabled; when *false, it will never be enabled.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -216,7 +216,7 @@ type Config struct {
 	CheckpointOracle *ctypes.CheckpointOracleConfig `toml:",omitempty"`
 
 	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
-	ECBP1100 *uint64 `toml:",omitempty"`
+	OverrideECBP1100 *uint64 `toml:",omitempty"`
 	// Manual configuration field for ECBP1100's disablement block number. Used for modifying genesis config via CLI flag.
 	OverrideECBP1100Deactivate *uint64 `toml:",omitempty"`
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -64,7 +64,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCTxFeeCap                float64
 		Checkpoint                 *ctypes.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle           *ctypes.CheckpointOracleConfig `toml:",omitempty"`
-		ECBP1100                   *uint64                        `toml:",omitempty"`
+		OverrideECBP1100           *uint64                        `toml:",omitempty"`
 		OverrideECBP1100Deactivate *uint64                        `toml:",omitempty"`
 		ECBP1100NoDisable          *bool                          `toml:",omitempty"`
 		OverrideShanghai           *uint64                        `toml:",omitempty"`
@@ -117,7 +117,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
-	enc.ECBP1100 = c.ECBP1100
+	enc.OverrideECBP1100 = c.OverrideECBP1100
 	enc.OverrideECBP1100Deactivate = c.OverrideECBP1100Deactivate
 	enc.ECBP1100NoDisable = c.ECBP1100NoDisable
 	enc.OverrideShanghai = c.OverrideShanghai
@@ -174,7 +174,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCTxFeeCap                *float64
 		Checkpoint                 *ctypes.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle           *ctypes.CheckpointOracleConfig `toml:",omitempty"`
-		ECBP1100                   *uint64                        `toml:",omitempty"`
+		OverrideECBP1100           *uint64                        `toml:",omitempty"`
 		OverrideECBP1100Deactivate *uint64                        `toml:",omitempty"`
 		ECBP1100NoDisable          *bool                          `toml:",omitempty"`
 		OverrideShanghai           *uint64                        `toml:",omitempty"`
@@ -320,8 +320,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.CheckpointOracle != nil {
 		c.CheckpointOracle = dec.CheckpointOracle
 	}
-	if dec.ECBP1100 != nil {
-		c.ECBP1100 = dec.ECBP1100
+	if dec.OverrideECBP1100 != nil {
+		c.OverrideECBP1100 = dec.OverrideECBP1100
 	}
 	if dec.OverrideECBP1100Deactivate != nil {
 		c.OverrideECBP1100Deactivate = dec.OverrideECBP1100Deactivate

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -64,12 +64,12 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCTxFeeCap                float64
 		Checkpoint                 *ctypes.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle           *ctypes.CheckpointOracleConfig `toml:",omitempty"`
-		ECBP1100                   *uint64
-		OverrideECBP1100Deactivate *uint64
-		ECBP1100NoDisable          *bool   `toml:",omitempty"`
-		OverrideShanghai           *uint64 `toml:",omitempty"`
-		OverrideCancun             *uint64 `toml:",omitempty"`
-		OverrideVerkle             *uint64 `toml:",omitempty"`
+		ECBP1100                   *uint64                        `toml:",omitempty"`
+		OverrideECBP1100Deactivate *uint64                        `toml:",omitempty"`
+		ECBP1100NoDisable          *bool                          `toml:",omitempty"`
+		OverrideShanghai           *uint64                        `toml:",omitempty"`
+		OverrideCancun             *uint64                        `toml:",omitempty"`
+		OverrideVerkle             *uint64                        `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -174,12 +174,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCTxFeeCap                *float64
 		Checkpoint                 *ctypes.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle           *ctypes.CheckpointOracleConfig `toml:",omitempty"`
-		ECBP1100                   *uint64
-		OverrideECBP1100Deactivate *uint64
-		ECBP1100NoDisable          *bool   `toml:",omitempty"`
-		OverrideShanghai           *uint64 `toml:",omitempty"`
-		OverrideCancun             *uint64 `toml:",omitempty"`
-		OverrideVerkle             *uint64 `toml:",omitempty"`
+		ECBP1100                   *uint64                        `toml:",omitempty"`
+		OverrideECBP1100Deactivate *uint64                        `toml:",omitempty"`
+		ECBP1100NoDisable          *bool                          `toml:",omitempty"`
+		OverrideShanghai           *uint64                        `toml:",omitempty"`
+		OverrideCancun             *uint64                        `toml:",omitempty"`
+		OverrideVerkle             *uint64                        `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -3,7 +3,6 @@
 package ethconfig
 
 import (
-	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -20,57 +19,57 @@ import (
 // MarshalTOML marshals as TOML.
 func (c Config) MarshalTOML() (interface{}, error) {
 	type Config struct {
-		Genesis                 *genesisT.Genesis `toml:",omitempty"`
-		NetworkId               uint64
-		ProtocolVersions        []uint
-		SyncMode                downloader.SyncMode
-		EthDiscoveryURLs        []string
-		SnapDiscoveryURLs       []string
-		NoPruning               bool
-		NoPrefetch              bool
-		TxLookupLimit           uint64                 `toml:",omitempty"`
-		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
-		LightServ               int                    `toml:",omitempty"`
-		LightIngress            int                    `toml:",omitempty"`
-		LightEgress             int                    `toml:",omitempty"`
-		LightPeers              int                    `toml:",omitempty"`
-		LightNoPrune            bool                   `toml:",omitempty"`
-		LightNoSyncServe        bool                   `toml:",omitempty"`
-		SyncFromCheckpoint      bool                   `toml:",omitempty"`
-		UltraLightServers       []string               `toml:",omitempty"`
-		UltraLightFraction      int                    `toml:",omitempty"`
-		UltraLightOnlyAnnounce  bool                   `toml:",omitempty"`
-		SkipBcVersionCheck      bool                   `toml:"-"`
-		DatabaseHandles         int                    `toml:"-"`
-		DatabaseCache           int
-		DatabaseFreezer         string
-		DatabaseFreezerRemote   string
-		TrieCleanCache          int
-		TrieDirtyCache          int
-		TrieTimeout             time.Duration
-		SnapshotCache           int
-		Preimages               bool
-		FilterLogCacheSize      int
-		Miner                   miner.Config
-		Ethash                  ethash.Config
-		TxPool                  legacypool.Config
-		BlobPool                blobpool.Config
-		GPO                     gasprice.Config
-		EnablePreimageRecording bool
-		DocRoot                 string `toml:"-"`
-		EWASMInterpreter        string
-		EVMInterpreter          string
-		RPCGasCap               uint64
-		RPCEVMTimeout           time.Duration
-		RPCTxFeeCap             float64
-		Checkpoint              *ctypes.TrustedCheckpoint      `toml:",omitempty"`
-		CheckpointOracle        *ctypes.CheckpointOracleConfig `toml:",omitempty"`
-		ECBP1100                *big.Int
-		ECBP1100Disable         *big.Int
-		ECBP1100NoDisable       *bool   `toml:",omitempty"`
-		OverrideShanghai        *uint64 `toml:",omitempty"`
-		OverrideCancun          *uint64 `toml:",omitempty"`
-		OverrideVerkle          *uint64 `toml:",omitempty"`
+		Genesis                    *genesisT.Genesis `toml:",omitempty"`
+		NetworkId                  uint64
+		ProtocolVersions           []uint
+		SyncMode                   downloader.SyncMode
+		EthDiscoveryURLs           []string
+		SnapDiscoveryURLs          []string
+		NoPruning                  bool
+		NoPrefetch                 bool
+		TxLookupLimit              uint64                 `toml:",omitempty"`
+		RequiredBlocks             map[uint64]common.Hash `toml:"-"`
+		LightServ                  int                    `toml:",omitempty"`
+		LightIngress               int                    `toml:",omitempty"`
+		LightEgress                int                    `toml:",omitempty"`
+		LightPeers                 int                    `toml:",omitempty"`
+		LightNoPrune               bool                   `toml:",omitempty"`
+		LightNoSyncServe           bool                   `toml:",omitempty"`
+		SyncFromCheckpoint         bool                   `toml:",omitempty"`
+		UltraLightServers          []string               `toml:",omitempty"`
+		UltraLightFraction         int                    `toml:",omitempty"`
+		UltraLightOnlyAnnounce     bool                   `toml:",omitempty"`
+		SkipBcVersionCheck         bool                   `toml:"-"`
+		DatabaseHandles            int                    `toml:"-"`
+		DatabaseCache              int
+		DatabaseFreezer            string
+		DatabaseFreezerRemote      string
+		TrieCleanCache             int
+		TrieDirtyCache             int
+		TrieTimeout                time.Duration
+		SnapshotCache              int
+		Preimages                  bool
+		FilterLogCacheSize         int
+		Miner                      miner.Config
+		Ethash                     ethash.Config
+		TxPool                     legacypool.Config
+		BlobPool                   blobpool.Config
+		GPO                        gasprice.Config
+		EnablePreimageRecording    bool
+		DocRoot                    string `toml:"-"`
+		EWASMInterpreter           string
+		EVMInterpreter             string
+		RPCGasCap                  uint64
+		RPCEVMTimeout              time.Duration
+		RPCTxFeeCap                float64
+		Checkpoint                 *ctypes.TrustedCheckpoint      `toml:",omitempty"`
+		CheckpointOracle           *ctypes.CheckpointOracleConfig `toml:",omitempty"`
+		ECBP1100                   *uint64
+		OverrideECBP1100Deactivate *uint64
+		ECBP1100NoDisable          *bool   `toml:",omitempty"`
+		OverrideShanghai           *uint64 `toml:",omitempty"`
+		OverrideCancun             *uint64 `toml:",omitempty"`
+		OverrideVerkle             *uint64 `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -119,9 +118,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.ECBP1100 = c.ECBP1100
-	enc.ECBP1100Disable = c.OverrideECBP1100Deactivate
+	enc.OverrideECBP1100Deactivate = c.OverrideECBP1100Deactivate
 	enc.ECBP1100NoDisable = c.ECBP1100NoDisable
-
 	enc.OverrideShanghai = c.OverrideShanghai
 	enc.OverrideCancun = c.OverrideCancun
 	enc.OverrideVerkle = c.OverrideVerkle
@@ -131,57 +129,57 @@ func (c Config) MarshalTOML() (interface{}, error) {
 // UnmarshalTOML unmarshals from TOML.
 func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type Config struct {
-		Genesis                 *genesisT.Genesis `toml:",omitempty"`
-		NetworkId               *uint64
-		ProtocolVersions        []uint
-		SyncMode                *downloader.SyncMode
-		EthDiscoveryURLs        []string
-		SnapDiscoveryURLs       []string
-		NoPruning               *bool
-		NoPrefetch              *bool
-		TxLookupLimit           *uint64                `toml:",omitempty"`
-		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
-		LightServ               *int                   `toml:",omitempty"`
-		LightIngress            *int                   `toml:",omitempty"`
-		LightEgress             *int                   `toml:",omitempty"`
-		LightPeers              *int                   `toml:",omitempty"`
-		LightNoPrune            *bool                  `toml:",omitempty"`
-		LightNoSyncServe        *bool                  `toml:",omitempty"`
-		SyncFromCheckpoint      *bool                  `toml:",omitempty"`
-		UltraLightServers       []string               `toml:",omitempty"`
-		UltraLightFraction      *int                   `toml:",omitempty"`
-		UltraLightOnlyAnnounce  *bool                  `toml:",omitempty"`
-		SkipBcVersionCheck      *bool                  `toml:"-"`
-		DatabaseHandles         *int                   `toml:"-"`
-		DatabaseCache           *int
-		DatabaseFreezer         *string
-		DatabaseFreezerRemote   *string
-		TrieCleanCache          *int
-		TrieDirtyCache          *int
-		TrieTimeout             *time.Duration
-		SnapshotCache           *int
-		Preimages               *bool
-		FilterLogCacheSize      *int
-		Miner                   *miner.Config
-		Ethash                  *ethash.Config
-		TxPool                  *legacypool.Config
-		BlobPool                *blobpool.Config
-		GPO                     *gasprice.Config
-		EnablePreimageRecording *bool
-		DocRoot                 *string `toml:"-"`
-		EWASMInterpreter        *string
-		EVMInterpreter          *string
-		RPCGasCap               *uint64
-		RPCEVMTimeout           *time.Duration
-		RPCTxFeeCap             *float64
-		Checkpoint              *ctypes.TrustedCheckpoint      `toml:",omitempty"`
-		CheckpointOracle        *ctypes.CheckpointOracleConfig `toml:",omitempty"`
-		ECBP1100                *big.Int
-		ECBP1100Disable         *big.Int
-		ECBP1100NoDisable       *bool   `toml:",omitempty"`
-		OverrideShanghai        *uint64 `toml:",omitempty"`
-		OverrideCancun          *uint64 `toml:",omitempty"`
-		OverrideVerkle          *uint64 `toml:",omitempty"`
+		Genesis                    *genesisT.Genesis `toml:",omitempty"`
+		NetworkId                  *uint64
+		ProtocolVersions           []uint
+		SyncMode                   *downloader.SyncMode
+		EthDiscoveryURLs           []string
+		SnapDiscoveryURLs          []string
+		NoPruning                  *bool
+		NoPrefetch                 *bool
+		TxLookupLimit              *uint64                `toml:",omitempty"`
+		RequiredBlocks             map[uint64]common.Hash `toml:"-"`
+		LightServ                  *int                   `toml:",omitempty"`
+		LightIngress               *int                   `toml:",omitempty"`
+		LightEgress                *int                   `toml:",omitempty"`
+		LightPeers                 *int                   `toml:",omitempty"`
+		LightNoPrune               *bool                  `toml:",omitempty"`
+		LightNoSyncServe           *bool                  `toml:",omitempty"`
+		SyncFromCheckpoint         *bool                  `toml:",omitempty"`
+		UltraLightServers          []string               `toml:",omitempty"`
+		UltraLightFraction         *int                   `toml:",omitempty"`
+		UltraLightOnlyAnnounce     *bool                  `toml:",omitempty"`
+		SkipBcVersionCheck         *bool                  `toml:"-"`
+		DatabaseHandles            *int                   `toml:"-"`
+		DatabaseCache              *int
+		DatabaseFreezer            *string
+		DatabaseFreezerRemote      *string
+		TrieCleanCache             *int
+		TrieDirtyCache             *int
+		TrieTimeout                *time.Duration
+		SnapshotCache              *int
+		Preimages                  *bool
+		FilterLogCacheSize         *int
+		Miner                      *miner.Config
+		Ethash                     *ethash.Config
+		TxPool                     *legacypool.Config
+		BlobPool                   *blobpool.Config
+		GPO                        *gasprice.Config
+		EnablePreimageRecording    *bool
+		DocRoot                    *string `toml:"-"`
+		EWASMInterpreter           *string
+		EVMInterpreter             *string
+		RPCGasCap                  *uint64
+		RPCEVMTimeout              *time.Duration
+		RPCTxFeeCap                *float64
+		Checkpoint                 *ctypes.TrustedCheckpoint      `toml:",omitempty"`
+		CheckpointOracle           *ctypes.CheckpointOracleConfig `toml:",omitempty"`
+		ECBP1100                   *uint64
+		OverrideECBP1100Deactivate *uint64
+		ECBP1100NoDisable          *bool   `toml:",omitempty"`
+		OverrideShanghai           *uint64 `toml:",omitempty"`
+		OverrideCancun             *uint64 `toml:",omitempty"`
+		OverrideVerkle             *uint64 `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -325,8 +323,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.ECBP1100 != nil {
 		c.ECBP1100 = dec.ECBP1100
 	}
-	if dec.ECBP1100Disable != nil {
-		c.OverrideECBP1100Deactivate = dec.ECBP1100Disable
+	if dec.OverrideECBP1100Deactivate != nil {
+		c.OverrideECBP1100Deactivate = dec.OverrideECBP1100Deactivate
 	}
 	if dec.ECBP1100NoDisable != nil {
 		c.ECBP1100NoDisable = dec.ECBP1100NoDisable

--- a/params/types/genesisT/gen_genesis.go
+++ b/params/types/genesisT/gen_genesis.go
@@ -10,10 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/params/confp/generic"
-	"github.com/ethereum/go-ethereum/params/types/coregeth"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
-	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
 var _ = (*genesisSpecMarshaling)(nil)
@@ -76,27 +73,11 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		Number        *math.HexOrDecimal64                        `json:"number"`
 		GasUsed       *math.HexOrDecimal64                        `json:"gasUsed"`
 		ParentHash    *common.Hash                                `json:"parentHash"`
-		BaseFee       *math.HexOrDecimal256                       `json:"baseFeePerGas"`
-		ExcessBlobGas *math.HexOrDecimal64                        `json:"excessBlobGas"`
-		BlobGasUsed   *math.HexOrDecimal64                        `json:"blobGasUsed"`
+		BaseFee       *math.HexOrDecimal256                       `json:"baseFeePerGas,omitempty"`
+		ExcessBlobGas *math.HexOrDecimal64                        `json:"excessBlobGas,omitempty"`
+		BlobGasUsed   *math.HexOrDecimal64                        `json:"blobGasUsed,omitempty"`
 	}
 	var dec Genesis
-	// We have to look at the raw input, decide what kind of configurator schema it's using,
-	// then assign the decoder struct to use that schema type.
-	conf, err := generic.UnmarshalChainConfigurator(input)
-	if err != nil {
-		return err
-	}
-
-	switch conf.(type) {
-	case *coregeth.CoreGethChainConfig:
-		dec.Config = &coregeth.CoreGethChainConfig{}
-	case *goethereum.ChainConfig:
-		dec.Config = &goethereum.ChainConfig{}
-	default:
-		panic("unmarshal genesis chain config returned a type not supported by unmarshaling")
-	}
-
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}

--- a/params/types/genesisT/gen_genesis.go
+++ b/params/types/genesisT/gen_genesis.go
@@ -10,7 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/params/confp/generic"
+	"github.com/ethereum/go-ethereum/params/types/coregeth"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
+	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
 var _ = (*genesisSpecMarshaling)(nil)
@@ -78,6 +81,22 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		BlobGasUsed   *math.HexOrDecimal64                        `json:"blobGasUsed,omitempty"`
 	}
 	var dec Genesis
+	// We have to look at the raw input, decide what kind of configurator schema it's using,
+	// then assign the decoder struct to use that schema type.
+	conf, err := generic.UnmarshalChainConfigurator(input)
+	if err != nil {
+		return err
+	}
+
+	switch conf.(type) {
+	case *coregeth.CoreGethChainConfig:
+		dec.Config = &coregeth.CoreGethChainConfig{}
+	case *goethereum.ChainConfig:
+		dec.Config = &goethereum.ChainConfig{}
+	default:
+		panic("unmarshal genesis chain config returned a type not supported by unmarshaling")
+	}
+
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}

--- a/params/types/genesisT/gen_genesis.go
+++ b/params/types/genesisT/gen_genesis.go
@@ -10,10 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/params/confp/generic"
-	"github.com/ethereum/go-ethereum/params/types/coregeth"
 	"github.com/ethereum/go-ethereum/params/types/ctypes"
-	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
 var _ = (*genesisSpecMarshaling)(nil)
@@ -81,22 +78,6 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		BlobGasUsed   *math.HexOrDecimal64                        `json:"blobGasUsed,omitempty"`
 	}
 	var dec Genesis
-	// We have to look at the raw input, decide what kind of configurator schema it's using,
-	// then assign the decoder struct to use that schema type.
-	conf, err := generic.UnmarshalChainConfigurator(input)
-	if err != nil {
-		return err
-	}
-
-	switch conf.(type) {
-	case *coregeth.CoreGethChainConfig:
-		dec.Config = &coregeth.CoreGethChainConfig{}
-	case *goethereum.ChainConfig:
-		dec.Config = &goethereum.ChainConfig{}
-	default:
-		panic("unmarshal genesis chain config returned a type not supported by unmarshaling")
-	}
-
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #613 

- [x] fix `ethconfig.Config` field data types for ECBP fields. These were `*big.Int` and should have been `*uint64`.  These data types percolate through `backend.go`.
```
	// Manual configuration field for ECBP1100 activation number. Used for modifying genesis config via CLI flag.
	ECBP1100 *uint64 `toml:",omitempty"`
	// Manual configuration field for ECBP1100's disablement block number. Used for modifying genesis config via CLI flag.
	OverrideECBP1100Deactivate *uint64 `toml:",omitempty"`
```
- [x]  `go generate` files were not up to date, so I ran `go generate -skip=trezor ./...
    - [x] and then manually edit `gen_genesis.go` to re-implement the config type switch between core-geth and go-ethereum config types (yuck!)
- [x]  install `workflow_dispatch` run trigger for the go-generate-check workflow, in addition to the existing `pull_request`
