### PR TITLE
Jenkinsfile: bump go version v1.20.3 -> v1.22.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,8 +21,8 @@ pipeline {
                 stage('Mordor') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -L -O https://go.dev/dl/go1.20.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.22.4.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz"
                         sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
                         sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"
@@ -41,8 +41,8 @@ pipeline {
                 stage('Goerli') {
                     agent { label "aws-slave-m5-xlarge" }
                     steps {
-                        sh "curl -L -O https://go.dev/dl/go1.20.3.linux-amd64.tar.gz"
-                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz"
+                        sh "curl -L -O https://go.dev/dl/go1.22.4.linux-amd64.tar.gz"
+                        sh "sudo rm -rf /usr/bin/go && sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz"
                         sh "sudo cp /usr/local/go/bin/go /usr/bin/go"
                         sh "sudo cp /usr/local/go/bin/gofmt /usr/bin/gofmt"
                         sh "go version"


### PR DESCRIPTION
This should fix an issue where Jenkins
complains about a missing package 'slices'.

https://ci.etccore.in/blue/organizations/jenkins/core-geth-regression/detail/core-geth-regression/327/pipeline#step-51-log-121

Date: 2024-06-08 08:25:37-06:00