### PR TITLE
Revert versioning change from #593

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 13         // Minor version component of the current release
-	VersionPatch = 0          // Patch version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 17         // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )


### PR DESCRIPTION
Inadvertently, #593 changed the _unstable_ version of `master`