### PR TITLE
Release/v1.12.20

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 12         // Minor version component of the current release
-	VersionPatch = 20         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 12       // Minor version component of the current release
+	VersionPatch = 20       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 20       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 21         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 


### PR DESCRIPTION
Comparison with last release: [v1.12.19..v1.12.20](https://github.com/etclabscore/core-geth/compare/v1.12.19..v1.12.20)
Docker images published under [etclabscore/core-geth](https://hub.docker.com/r/etclabscore/core-geth/builds).