### PR TITLE
Introduce MintMe hardfork to enable PUSH0 and MCOPY opcodes

### DIFF
--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -226,7 +226,8 @@ func TestCreation(t *testing.T) {
 			core.GenesisToBlock(params.DefaultMintMeGenesisBlock(), nil),
 			[]testcase{
 				{0, 0, ID{Hash: checksumToBytes(0x02bf4180), Next: 252500}},
-				{252500, 0, ID{Hash: checksumToBytes(0x50aed09f), Next: 0}},
+				{252500, 0, ID{Hash: checksumToBytes(0x50aed09f), Next: 8_784_700}},
+				{8_784_700, 0, ID{Hash: checksumToBytes(0x0a67075a), Next: 0}},
 			},
 		},
 	}
@@ -529,7 +530,7 @@ func TestGatherForks(t *testing.T) {
 		{
 			"mintme",
 			params.MintMeChainConfig,
-			[]uint64{252_500},
+			[]uint64{252_500, 8_784_700},
 			[]uint64{},
 		},
 	}

--- a/params/config_mintme.go
+++ b/params/config_mintme.go
@@ -66,6 +66,12 @@ var (
 		EIP2028FBlock: big.NewInt(0),
 		EIP2200FBlock: big.NewInt(0), // RePetersburg (== re-1283)
 
+		// Shangai
+		EIP3855FBlock: big.NewInt(8784700),
+
+		// Cancun
+		EIP5656FBlock: big.NewInt(8784700),
+
 		ECIP1099FBlock: nil, // Etchash
 
 		DisposalBlock:      big.NewInt(0), // Dispose difficulty bomb


### PR DESCRIPTION
This pull request introduces support for MintMe mainnet network upgrade at height 8,784,700. Hardfork will occur on approximately 2025-01-16 07:02 UTC.

It enables PUSH0 (EIP-3855) and MCOPY (EIP-5656) opcodes.