### PR TITLE
Update GitHub Actions Artifacts to v4

### DIFF
--- a/.github/workflows/bench-core.yml
+++ b/.github/workflows/bench-core.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           go test -short ./core -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee core-geth.txt
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: core-geth
           path: ./core-geth.txt
@@ -51,7 +51,7 @@ jobs:
         run: |
           go test -short ./core -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee go-ethereum.txt
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: go-ethereum
           path: ./go-ethereum.txt
@@ -75,12 +75,13 @@ jobs:
         run: |
           go install golang.org/x/perf/cmd/benchstat@latest
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         name: Get go-ethereum artifact
         with:
           name: go-ethereum
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         name: Get core-geth artifact
         with:
           name: core-geth

--- a/.github/workflows/bench-trie.yml
+++ b/.github/workflows/bench-trie.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           go test -short ./trie -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee core-geth.txt
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: core-geth
           path: ./core-geth.txt
@@ -51,7 +51,7 @@ jobs:
         run: |
           go test -short ./trie -count 1 -p 1 -timeout 60m -run NONE -bench=. -v |& tee go-ethereum.txt
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: go-ethereum
           path: ./go-ethereum.txt
@@ -75,12 +75,12 @@ jobs:
         run: |
           go install golang.org/x/perf/cmd/benchstat@latest
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         name: Get go-ethereum artifact
         with:
           name: go-ethereum
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         name: Get core-geth artifact
         with:
           name: core-geth

--- a/.github/workflows/bench-vm.yml
+++ b/.github/workflows/bench-vm.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           go test -short ./tests -count 1 -p 1 -timeout 60m -run NONE -bench=VM -v |& tee core-geth.txt
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: core-geth
           path: ./core-geth.txt
@@ -57,7 +57,7 @@ jobs:
           git checkout $GITHUB_SHA -- tests/vm_bench_test.go
           go test -short ./tests -count 1 -p 1 -timeout 60m -run NONE -bench=VM -v |& tee go-ethereum.txt
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: go-ethereum
           path: ./go-ethereum.txt
@@ -81,12 +81,12 @@ jobs:
         run: |
           go install golang.org/x/perf/cmd/benchstat@latest
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         name: Get go-ethereum artifact
         with:
           name: go-ethereum
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         name: Get core-geth artifact
         with:
           name: core-geth


### PR DESCRIPTION
Update `actions/upload-artifact`, `actions/download-artifact` GitHub Actions to v4 due to a [deprecation notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). This can only be tested once merged to _master_