### PR TITLE
refactor: Directly swap variable values

### DIFF
--- a/cmd/devp2p/internal/ethtest/chain.go
+++ b/cmd/devp2p/internal/ethtest/chain.go
@@ -277,9 +277,7 @@ func (a Addresses) Less(i, j int) bool {
 }
 
 func (a Addresses) Swap(i, j int) {
-	tmp := a[i]
-	a[i] = a[j]
-	a[j] = tmp
+	a[i], a[j] = a[j], a[i]
 }
 
 func blocksFromFile(chainfile string, gblock *types.Block) ([]*types.Block, error) {


### PR DESCRIPTION
Directly exchange the values ​​of two variables to avoid introducing temporary variables.