### PR TITLE
Fix space in //go:noescape directive

### DIFF
--- a/crypto/bn256/cloudflare/gfp_decl.go
+++ b/crypto/bn256/cloudflare/gfp_decl.go
@@ -13,7 +13,7 @@ import (
 //nolint:varcheck,unused,deadcode
 var hasBMI2 = cpu.X86.HasBMI2
 
-// go:noescape
+//go:noescape
 func gfpNeg(c, a *gfP)
 
 //go:noescape


### PR DESCRIPTION
Fix unnecessary space in the "//go:noescape" directive to resolve ineffectual compiler directive warning.