### PR TITLE
Release v1.12.21: Security hotfix for P2P crash-loop

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -20,13 +20,13 @@ jobs:
         - os: macos-latest
           BUILD_OS_NAME: osx
 
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           BUILD_OS_NAME: linux
 
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           BUILD_OS_NAME: arm
 
-        - os: windows-latest
+        - os: windows-2022
           BUILD_OS_NAME: win64
 
     steps:

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -290,7 +290,7 @@ func (prv *PrivateKey) Decrypt(c, s1, s2 []byte) (m []byte, err error) {
 	switch c[0] {
 	case 2, 3, 4:
 		rLen = (prv.PublicKey.Curve.Params().BitSize + 7) / 4
-		if len(c) < (rLen + hLen + 1) {
+		if len(c) < (rLen + hLen + params.BlockSize) {
 			return nil, ErrInvalidMessage
 		}
 	default:

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -124,6 +124,9 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	if prv.PublicKey.Curve != pub.Curve {
 		return nil, ErrInvalidCurve
 	}
+	if pub.X == nil || pub.Y == nil || !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+		return nil, ErrInvalidPublicKey
+	}
 	if skLen+macLen > MaxSharedKeyLength(pub) {
 		return nil, ErrSharedKeyTooBig
 	}

--- a/p2p/rlpx/rlpx.go
+++ b/p2p/rlpx/rlpx.go
@@ -604,6 +604,11 @@ func (h *handshakeState) readMsg(msg interface{}, prv *ecdsa.PrivateKey, r io.Re
 	}
 	size := binary.BigEndian.Uint16(prefix)
 
+	// baseProtocolMaxMsgSize = 2 * 1024
+	if size > 2048 {
+		return nil, errors.New("message too big")
+	}
+
 	// Read the handshake packet.
 	packet, err := h.rbuf.read(r, int(size))
 	if err != nil {

--- a/p2p/rlpx/rlpx_oracle_poc_test.go
+++ b/p2p/rlpx/rlpx_oracle_poc_test.go
@@ -1,0 +1,57 @@
+package rlpx
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+)
+
+func TestHandshakeECIESInvalidCurveOracle(t *testing.T) {
+	initKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	respKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	init := handshakeState{
+		initiator: true,
+		remote:    ecies.ImportECDSAPublic(&respKey.PublicKey),
+	}
+	authMsg, err := init.makeAuthMsg(initKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet, err := init.sealEIP8(authMsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var recv handshakeState
+	if _, err := recv.readMsg(new(authMsgV4), respKey, bytes.NewReader(packet)); err != nil {
+		t.Fatalf("expected valid packet to decrypt: %v", err)
+	}
+
+	tampered := append([]byte(nil), packet...)
+	if len(tampered) < 2+65 {
+		t.Fatalf("unexpected packet length %d", len(tampered))
+	}
+	tampered[2] = 0x04
+	for i := 1; i < 65; i++ {
+		tampered[2+i] = 0x00
+	}
+
+	var recv2 handshakeState
+	_, err = recv2.readMsg(new(authMsgV4), respKey, bytes.NewReader(tampered))
+	if err == nil {
+		t.Fatal("expected decryption failure for invalid curve point")
+	}
+	if !errors.Is(err, ecies.ErrInvalidPublicKey) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 21       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 12         // Minor version component of the current release
+	VersionPatch = 22         // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 12       // Minor version component of the current release
-	VersionPatch = 20       // Patch version component of the current release
+	VersionPatch = 21       // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "CoreGeth"
 )


### PR DESCRIPTION
## Summary

- Cherry-pick 3 upstream security fixes (from v1.12.20 tag, not master) to address active P2P crash-loop attack on ETC bootnodes
- `crypto/ecies`: use AES blocksize for minimum ciphertext length check
- `crypto/ecies`: validate public key is on curve before ECDH (invalid-curve oracle fix)
- `p2p/rlpx`: enforce 2KB maximum size for handshake messages
- Version bump v1.12.20 → v1.12.21-stable → v1.12.22-unstable

## Context

Bootnodes classic (ams3, sfo3) were in a crash-loop caused by malicious P2P traffic exploiting missing input validation in the ECIES handshake path. The patched binary has been running stable on ams3. sfo3 remains in crash-loop (restart counter 805+) on v1.12.20, confirming the attack is ongoing.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all failures preexisting, unrelated)
- [x] `go test ./crypto/ecies/... ./p2p/rlpx/...` — PASS
- [x] `go run build/ci.go lint` — "You have achieved perfection"
- [x] All commits GPG-signed, tag GPG-signed
- [x] Cherry-pick patches verified byte-identical to upstream originals
- [x] Confirmed patched binary stable on ams3, unpatched sfo3 still crash-looping
- [ ] CI generates 34 release artifacts
- [ ] Verify artifact checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)